### PR TITLE
Separate pre-migration and migration steps for content

### DIFF
--- a/pulp_2to3_migrate/app/constants.py
+++ b/pulp_2to3_migrate/app/constants.py
@@ -1,3 +1,6 @@
+# temporary hack, to move gradually to one migrator
+from pulp_2to3_migrate.app.plugin.iso.pulp3.migrator import IsoMigrator
+
 # for tasking system to ensure only one migration is run at a time
 PULP_2TO3_MIGRATION_RESOURCE = 'pulp_2to3_migration'
 
@@ -63,3 +66,7 @@ PULP_2TO3_IMPORTER_TYPE_MODEL_MAP = {
 # PULP_2TO3_DISTRIBUTOR_TYPE_MODEL_MAP = {
 #     'iso': [('iso_distributor', 'IsoDistributor'),]
 # }
+
+PLUGIN_MIGRATORS_MAP = {
+    'iso': IsoMigrator
+}

--- a/pulp_2to3_migrate/app/models/content.py
+++ b/pulp_2to3_migrate/app/models/content.py
@@ -30,7 +30,6 @@ class Pulp2Content(Model):
     class Meta:
         unique_together = ('pulp2_id', 'pulp2_content_type_id')
 
-
     @property
     def detail_model(self):
         return getattr(self, f'{self.pulp2_content_type_id}_detail_model').get()
@@ -65,19 +64,6 @@ class Pulp2to3Content(Model):
         >>>                              pulp2content=pulp2_map[iso.id])
         >>>                     for iso in pulp2_iso_content_batch]
         >>> cls.objects.bulk_create(pulp2iso_to_save, ignore_conflicts=True)
-        """
-        raise NotImplementedError()
-
-    @classmethod
-    async def migrate_content_to_pulp3(cls):
-        """
-        Migrate pre-migrated Pulp 2 content.
-
-        Create a DeclatativeContentMigration pipeline here and instantiate it with your first stage.
-        Here the default implementation of the first stage is used:
-        >>> first_stage = ContentMigrationFirstStage(cls)
-        >>> dv = DeclarativeContentMigration(first_stage=first_stage)
-        >>> await dv.create()
         """
         raise NotImplementedError()
 

--- a/pulp_2to3_migrate/app/plugin/api.py
+++ b/pulp_2to3_migrate/app/plugin/api.py
@@ -4,4 +4,5 @@ from .content import (  # noqa
     RelatePulp2to3Content,
 )
 
+from .migrator import Pulp2to3PluginMigrator  # noqa
 from .repository import Pulp2to3Importer  # noqa

--- a/pulp_2to3_migrate/app/plugin/iso/pulp3/migrator.py
+++ b/pulp_2to3_migrate/app/plugin/iso/pulp3/migrator.py
@@ -1,0 +1,24 @@
+from pulp_2to3_migrate.app.plugin.api import (
+    ContentMigrationFirstStage,
+    DeclarativeContentMigration,
+    Pulp2to3PluginMigrator,
+)
+
+from .models import Pulp2ISO
+
+
+class IsoMigrator(Pulp2to3PluginMigrator):
+    """
+    An entry point for migration the Pulp 2 ISO plugin to Pulp 3.
+    """
+    type = 'iso'
+    content_models = (Pulp2ISO,)
+
+    @classmethod
+    async def migrate_content_to_pulp3(cls):
+        """
+        Migrate pre-migrated Pulp 2 ISO content.
+        """
+        first_stage = ContentMigrationFirstStage(cls)
+        dm = DeclarativeContentMigration(first_stage=first_stage)
+        await dm.create()

--- a/pulp_2to3_migrate/app/plugin/iso/pulp3/models.py
+++ b/pulp_2to3_migrate/app/plugin/iso/pulp3/models.py
@@ -1,11 +1,6 @@
 from django.db import models
 
 from pulp_2to3_migrate.app.models import Pulp2to3Content
-
-from pulp_2to3_migrate.app.plugin.api import (
-    ContentMigrationFirstStage,
-    DeclarativeContentMigration,
-)
 from pulp_2to3_migrate.app.plugin.iso.pulp2.models import ISO
 
 from pulp_file.app.models import FileContent
@@ -57,15 +52,6 @@ class Pulp2ISO(Pulp2to3Content):
                                      pulp2content=pulp2_id_obj_map[iso.id])
                             for iso in pulp2_iso_content_batch]
         cls.objects.bulk_create(pulp2iso_to_save, ignore_conflicts=True)
-
-    @classmethod
-    async def migrate_content_to_pulp3(cls):
-        """
-        Migrate pre-migrated Pulp 2 ISO content.
-        """
-        first_stage = ContentMigrationFirstStage(cls)
-        dv = DeclarativeContentMigration(first_stage=first_stage)
-        await dv.create()
 
     def create_pulp3_content(self):
         """

--- a/pulp_2to3_migrate/app/plugin/migrator.py
+++ b/pulp_2to3_migrate/app/plugin/migrator.py
@@ -1,0 +1,23 @@
+class Pulp2to3PluginMigrator:
+    """
+    Class to serve as a plugin interface for migration to Pulp 3.
+
+    Attributes:
+        type(str): migrator type which corresponds to a Pulp 2 plugin name
+        content_models(tuple): Pulp2to3Content models this migrator is responsible for
+    """
+    type = 'pulp2 plugin name'
+    content_models = ()
+
+    @classmethod
+    async def migrate_to_pulp3(cls):
+        """
+        Migrate all pre-migrated plugin content to Pulp 3.
+
+        Create a DeclatativeContentMigration pipeline here and instantiate it with your first stage.
+        Here the default implementation of the first stage is used:
+        >>> first_stage = ContentMigrationFirstStage(cls)
+        >>> dm = DeclarativeContentMigration(first_stage=first_stage)
+        >>> await dm.create()
+        """
+        raise NotImplementedError()

--- a/pulp_2to3_migrate/app/tasks/migrate.py
+++ b/pulp_2to3_migrate/app/tasks/migrate.py
@@ -1,14 +1,11 @@
 import asyncio
-import importlib
 import logging
 
-from collections import namedtuple
-
-from pulp_2to3_migrate.app.constants import (
-    PULP_2TO3_CONTENT_MODEL_MAP,
-    SUPPORTED_PULP2_PLUGINS,
+from pulp_2to3_migrate.app.pre_migration import (
+    pre_migrate_all_content,
+    pre_migrate_all_without_content,
 )
-from pulp_2to3_migrate.app.pre_migration import pre_migrate_all_without_content
+
 from pulp_2to3_migrate.app.migration import (
     migrate_content,
     migrate_importers,
@@ -17,10 +14,8 @@ from pulp_2to3_migrate.app.migration import (
 from pulp_2to3_migrate.app.models import MigrationPlan
 from pulp_2to3_migrate.pulp2 import connection
 
+
 _logger = logging.getLogger(__name__)
-
-
-ContentModel = namedtuple('ContentModel', ['pulp2', 'pulp_2to3_detail'])
 
 
 def migrate_from_pulp2(migration_plan_pk, dry_run=False):
@@ -46,33 +41,12 @@ def migrate_from_pulp2(migration_plan_pk, dry_run=False):
     # For now, the list of plugins to migrate is hard-coded.
     plugins_to_migrate = ['iso']
 
-    # import all pulp 2 content models
-    # (for each content type: one works with mongo and other - with postgresql)
-    content_models = []
-    for plugin, model_names in SUPPORTED_PULP2_PLUGINS.items():
-        if plugin not in plugins_to_migrate:
-            continue
-        pulp2_module_path = 'pulp_2to3_migrate.app.plugin.{plugin}.pulp2.models'.format(
-            plugin=plugin)
-        pulp2_module = importlib.import_module(pulp2_module_path)
-        pulp_2to3_module = importlib.import_module('pulp_2to3_migrate.app.models')
-        for pulp2_content_model_name in model_names:
-            # mongodb model
-            pulp2_content_model = getattr(pulp2_module, pulp2_content_model_name)
-
-            # postgresql model
-            content_type = pulp2_content_model.type
-            pulp_2to3_detail_model_name = PULP_2TO3_CONTENT_MODEL_MAP[content_type]
-            pulp_2to3_detail_model = getattr(pulp_2to3_module, pulp_2to3_detail_model_name)
-
-            content_models.append(ContentModel(pulp2=pulp2_content_model,
-                                               pulp_2to3_detail=pulp_2to3_detail_model))
-
     loop = asyncio.get_event_loop()
     loop.run_until_complete(pre_migrate_all_without_content(plan))
     loop.run_until_complete(migrate_repositories())
     loop.run_until_complete(migrate_importers(plugins_to_migrate))
-    loop.run_until_complete(migrate_content(content_models))  # without RemoteArtifacts yet
+    loop.run_until_complete(pre_migrate_all_content(plugins_to_migrate))
+    loop.run_until_complete(migrate_content(plugins_to_migrate))  # without RemoteArtifacts yet
 #    loop.run_until_complete(create_repo_versions())
 #    loop.run_until_complete(migrate_distributors(plugins_to_migrate))
     loop.close()


### PR DESCRIPTION
Give plugins more control over migration flow.
Introduce a migrator interface.

closes #5476
https://pulp.plan.io/issues/5476