### PR TITLE
Don't migrate importers/distributors with an empty config

### DIFF
--- a/CHANGES/5551.bugfix
+++ b/CHANGES/5551.bugfix
@@ -1,0 +1,1 @@
+Prevent migration of importers/distributors with an empty config.


### PR DESCRIPTION
There is nothing to migrate to Pulp3 in this case.

closes #5551
https://pulp.plan.io/issues/5551