### PR TITLE
Create repo versions

### DIFF
--- a/CHANGES/5342.feature
+++ b/CHANGES/5342.feature
@@ -1,0 +1,1 @@
+Migrate Pulp 2 repositories into Pulp 3 repo versions.

--- a/pulp_2to3_migration/app/models/base.py
+++ b/pulp_2to3_migration/app/models/base.py
@@ -134,7 +134,7 @@ class _InternalMigrationPlan:
             self.repositories_to_migrate.append(pulp2_repository_id)
             repository_versions.append(pulp2_repository_id)
 
-            distributor_ids = repository_version.get('distributor_ids')
+            distributor_ids = repository_version.get('distributor_ids', [])
             self.distributors_to_migrate.extend(distributor_ids)
 
         return repository_versions

--- a/pulp_2to3_migration/app/tasks/migrate.py
+++ b/pulp_2to3_migration/app/tasks/migrate.py
@@ -7,6 +7,7 @@ from pulp_2to3_migration.app.pre_migration import (
 )
 
 from pulp_2to3_migration.app.migration import (
+    create_repo_versions,
     migrate_content,
     migrate_importers,
     migrate_repositories,
@@ -51,7 +52,7 @@ def migrate_from_pulp2(migration_plan_pk, validate=False, dry_run=False):
     loop.run_until_complete(migrate_repositories(plan))
     loop.run_until_complete(migrate_importers(plan))
     loop.run_until_complete(pre_migrate_all_content(plan))
-    loop.run_until_complete(migrate_content(plan))  # without RemoteArtifacts yet
-#    loop.run_until_complete(create_repo_versions(plan))
+    loop.run_until_complete(migrate_content(plan))
+    loop.run_until_complete(create_repo_versions(plan))
 #    loop.run_until_complete(migrate_distributors(plugins_to_migrate))
     loop.close()


### PR DESCRIPTION
By default, create one repo version per each pulp 2 repo.
If the specific migration plan exists for repo version creation, follow it.

Repositories are created based on the provided name in the migration plan.
If such repo exists in pulp 2, its description will be migrated, otherwise
Pulp 3 repo is created with the descritpion as its name.

closes #5342
https://pulp.plan.io/issues/5342