### PR TITLE
Adds functional test that migrates 4 ISO repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,6 @@ python:
 env:
   matrix:
     - TEST=pulp
-    - TEST=bindings
-matrix:
-  exclude:
-    - python: '3.6'
-      env: TEST=bindings
-  fast_finish: true
 services:
   - postgresql
   - redis-server
@@ -50,6 +44,14 @@ after_failure:
   - sudo kubectl logs -l app=pulp-worker --tail=10000
 jobs:
   include:
+    # So long as we have a build matrix of only 1 build (via only 1 python
+    # version), we need this as a stub for the default implicit stage also
+    # called "test".
+    # It must be removed once there is more than 1 build, or else there will be
+    # an additional build.
+    # https://github.com/travis-ci/travis-ci/issues/8536
+    # https://github.com/travis-ci/travis-ci/issues/4681
+    - stage: test
     - stage: deploy-plugin-to-pypi
       before_install: skip
       install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ services:
   - postgresql
   - redis-server
   - docker
+  - mongodb
 addons:
   apt:
     packages:

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -31,12 +31,14 @@ then
   export PULP_ROLES_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/ansible-pulp\/pull\/(\d+)' | awk -F'/' '{print $7}')
   export PULP_BINDINGS_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp-openapi-generator\/pull\/(\d+)' | awk -F'/' '{print $7}')
   export PULP_OPERATOR_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp-operator\/pull\/(\d+)' | awk -F'/' '{print $7}')
+  export PULP_BINDINGS_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp-openapi-generator\/pull\/(\d+)' | awk -F'/' '{print $7}')
 else
   export PULP_PR_NUMBER=
   export PULP_SMASH_PR_NUMBER=
   export PULP_ROLES_PR_NUMBER=
   export PULP_BINDINGS_PR_NUMBER=
   export PULP_OPERATOR_PR_NUMBER=
+  export PULP_BINDINGS_PR_NUMBER=
 fi
 
 # dev_requirements contains tools needed for flake8, etc.
@@ -70,6 +72,14 @@ if [ -n "$PULP_OPERATOR_PR_NUMBER" ]; then
   curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
   chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu && sudo mkdir -p /usr/local/bin/ && sudo cp operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/operator-sdk && rm operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
   sudo operator-sdk build --image-builder=docker quay.io/pulp/pulp-operator:latest
+  cd ..
+fi
+
+git clone https://github.com/pulp/pulp-openapi-generator.git
+if [ -n "$PULP_BINDINGS_PR_NUMBER" ]; then
+  cd pulp-openapi-generator
+  git fetch origin +refs/pull/$PULP_BINDINGS_PR_NUMBER/merge
+  git checkout FETCH_HEAD
   cd ..
 fi
 

--- a/.travis/check_commit.sh
+++ b/.travis/check_commit.sh
@@ -29,6 +29,7 @@ fi
 
 for sha in `git log --format=oneline --no-merges "$RANGE" | cut '-d ' -f1`
 do
+  pip install requests
   python .travis/validate_commit_message.py $sha
   VALUE=$?
 

--- a/.travis/func_test_script.sh
+++ b/.travis/func_test_script.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# coding=utf-8
+
+set -mveuo pipefail
+
+# Note: This function is in the process of being merged into after_failure
+show_logs_and_return_non_zero() {
+  readonly local rc="$?"
+  return "${rc}"
+}
+export -f show_logs_and_return_non_zero
+
+# Run functional tests
+set +u
+
+export PYTHONPATH=$TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR/../pulpcore:${PYTHONPATH}
+export DJANGO_SETTINGS_MODULE=pulpcore.app.settings
+export PULP_CONTENT_ORIGIN=http://localhost
+
+set -u
+
+pytest -v -r sx --color=yes --pyargs pulp_2to3_migration.tests.functional || show_logs_and_return_non_zero

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -112,6 +112,7 @@ spec:
     username: pulp
     password: pulp
     admin_password: pulp
+
 CRYAML
 
 # Install k3s, lightweight Kubernetes

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -91,7 +91,7 @@ images:
         - $PULP_CONTAINER
 VARSYAML
 fi
-ansible-playbook build.yaml
+ansible-playbook -v build.yaml
 
 cd $TRAVIS_BUILD_DIR/../pulp-operator
 # Tell pulp-perator to deploy our image
@@ -112,7 +112,6 @@ spec:
     username: pulp
     password: pulp
     admin_password: pulp
-
 CRYAML
 
 # Install k3s, lightweight Kubernetes

--- a/.travis/post_before_install.sh
+++ b/.travis/post_before_install.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -mveuo pipefail
+
+sed -i "s/'seeds': 'localhost:27017'/'seeds': '$(hostname):27017'/g" $TRAVIS_BUILD_DIR/pulp_2to3_migration/app/settings.py
+sed -i "s/'username': ''/'username': 'travis'/g" $TRAVIS_BUILD_DIR/pulp_2to3_migration/app/settings.py
+sed -i "s/'password': ''/'password': 'travis'/g" $TRAVIS_BUILD_DIR/pulp_2to3_migration/app/settings.py

--- a/.travis/post_before_script.sh
+++ b/.travis/post_before_script.sh
@@ -14,9 +14,7 @@ mongorestore --archive=pulp2filecontent.20191031.archive
 
 mongo pulp_database --eval 'db.createUser({user:"travis",pwd:"travis",roles:["readWrite"]});'
 
-cd ..
-git clone https://github.com/pulp/pulp-openapi-generator.git
-cd pulp-openapi-generator
+cd ../pulp-openapi-generator
 
 ./generate.sh pulpcore python
 pip install ./pulpcore-client

--- a/.travis/post_before_script.sh
+++ b/.travis/post_before_script.sh
@@ -8,3 +8,15 @@ $CMD_PREFIX bash -c "mv pulp-2to3-migration-test-fixtures/20191031/var/lib/pulp/
 
 wget https://github.com/pulp/pulp-2to3-migration-test-fixtures/raw/master/20191031/pulp2filecontent.20191031.archive
 mongorestore --archive=pulp2filecontent.20191031.archive
+
+cd ..
+git clone https://github.com/pulp/pulp-openapi-generator.git
+cd pulp-openapi-generator
+
+./generate.sh pulpcore python
+pip install ./pulpcore-client
+./generate.sh pulp_file python
+pip install ./pulp_file-client
+./generate.sh pulp_2to3_migration python
+pip install ./pulp_2to3_migration-client
+

--- a/.travis/post_before_script.sh
+++ b/.travis/post_before_script.sh
@@ -2,12 +2,17 @@
 
 set -euv
 
+sudo sed -i  "s/bindIp: 127.0.0.1/bindIp: 127.0.0.1,$(ip address show dev ens4 | grep -o "inet [0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | grep -o "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*")/g" /etc/mongod.conf
+sudo systemctl restart mongod
+
 $CMD_PREFIX bash -c "git clone https://github.com/pulp/pulp-2to3-migration-test-fixtures"
 $CMD_PREFIX bash -c "mv pulp-2to3-migration-test-fixtures/20191031/var/lib/pulp/content /var/lib/pulp/content"
 $CMD_PREFIX bash -c "mv pulp-2to3-migration-test-fixtures/20191031/var/lib/pulp/published /var/lib/pulp/published"
 
 wget https://github.com/pulp/pulp-2to3-migration-test-fixtures/raw/master/20191031/pulp2filecontent.20191031.archive
 mongorestore --archive=pulp2filecontent.20191031.archive
+
+mongo pulp_database --eval 'db.createUser({user:"travis",pwd:"travis",roles:["readWrite"]});'
 
 cd ..
 git clone https://github.com/pulp/pulp-openapi-generator.git

--- a/.travis/post_before_script.sh
+++ b/.travis/post_before_script.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euv
+
+$CMD_PREFIX bash -c "git clone https://github.com/pulp/pulp-2to3-migration-test-fixtures"
+$CMD_PREFIX bash -c "mv pulp-2to3-migration-test-fixtures/20191031/var/lib/pulp/content /var/lib/pulp/content"
+$CMD_PREFIX bash -c "mv pulp-2to3-migration-test-fixtures/20191031/var/lib/pulp/published /var/lib/pulp/published"
+
+wget https://github.com/pulp/pulp-2to3-migration-test-fixtures/raw/master/20191031/pulp2filecontent.20191031.archive
+mongorestore --archive=pulp2filecontent.20191031.archive

--- a/.travis/post_before_script.sh
+++ b/.travis/post_before_script.sh
@@ -24,5 +24,3 @@ pip install ./pulpcore-client
 pip install ./pulp_file-client
 ./generate.sh pulp_2to3_migration python
 pip install ./pulp_2to3_migration-client
-
-export PULP_CONTENT_ORIGIN=http://localhost

--- a/.travis/post_before_script.sh
+++ b/.travis/post_before_script.sh
@@ -14,6 +14,8 @@ mongorestore --archive=pulp2filecontent.20191031.archive
 
 mongo pulp_database --eval 'db.createUser({user:"travis",pwd:"travis",roles:["readWrite"]});'
 
+pip install .
+
 cd ../pulp-openapi-generator
 
 ./generate.sh pulpcore python
@@ -23,3 +25,4 @@ pip install ./pulp_file-client
 ./generate.sh pulp_2to3_migration python
 pip install ./pulp_2to3_migration-client
 
+export PULP_CONTENT_ORIGIN=http://localhost

--- a/.travis/publish_client_pypi.sh
+++ b/.travis/publish_client_pypi.sh
@@ -40,5 +40,6 @@ cd pulp-openapi-generator
 ./generate.sh pulp_2to3_migration python $VERSION
 cd pulp_2to3_migration-client
 python setup.py sdist bdist_wheel --python-tag py3
+twine check dist/* || exit 1
 twine upload dist/* -u pulp -p $PYPI_PASSWORD
 exit $?

--- a/.travis/publish_plugin_pypi.sh
+++ b/.travis/publish_plugin_pypi.sh
@@ -12,4 +12,5 @@ set -euv
 pip install twine
 
 python setup.py sdist bdist_wheel --python-tag py3
+twine check dist/* || exit 1
 twine upload dist/* -u pulp -p $PYPI_PASSWORD

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -20,6 +20,8 @@ export FUNC_TEST_SCRIPT=$TRAVIS_BUILD_DIR/.travis/func_test_script.sh
 export DJANGO_SETTINGS_MODULE=pulpcore.app.settings
 
 if [ "$TEST" = 'docs' ]; then
+  
+
   cd docs
   make html
   cd ..
@@ -31,12 +33,7 @@ if [ "$TEST" = 'docs' ]; then
 fi
 
 if [ "$TEST" = 'bindings' ]; then
-  COMMIT_MSG=$(git log --format=%B --no-merges -1)
-  export PULP_BINDINGS_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp-openapi-generator\/pull\/(\d+)' | awk -F'/' '{print $7}')
-
-  cd ..
-  git clone https://github.com/pulp/pulp-openapi-generator.git
-  cd pulp-openapi-generator
+  cd ../pulp-openapi-generator
 
   if [ -n "$PULP_BINDINGS_PR_NUMBER" ]; then
     git fetch origin +refs/pull/$PULP_BINDINGS_PR_NUMBER/merge
@@ -107,7 +104,11 @@ set -u
 
 if [[ "$TEST" == "performance" ]]; then
   echo "--- Performance Tests ---"
-  pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 pulp_2to3_migration.tests.performance || show_logs_and_return_non_zero
+  if [[ -z "$PERFORMANCE_TEST" ]]; then
+    pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 pulp_2to3_migration.tests.performance || show_logs_and_return_non_zero
+  else
+    pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 pulp_2to3_migration.tests.performance.test_$PERFORMANCE_TEST || show_logs_and_return_non_zero
+  fi
   exit
 fi
 

--- a/.travis/validate_commit_message.py
+++ b/.travis/validate_commit_message.py
@@ -13,7 +13,7 @@ import sys
 
 KEYWORDS = ["fixes", "closes", "re", "ref"]
 NO_ISSUE = "[noissue]"
-STATUSES = ["NEW", "ASSIGNED", "POST"]
+STATUSES = ["NEW", "ASSIGNED", "POST", "MODIFIED"]
 
 sha = sys.argv[1]
 message = subprocess.check_output(["git", "log", "--format=%B", "-n 1", sha]).decode("utf-8")

--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -1,0 +1,2 @@
+mongoengine
+semantic-version

--- a/pulp_2to3_migration/tests/functional/test_file_migration.py
+++ b/pulp_2to3_migration/tests/functional/test_file_migration.py
@@ -1,9 +1,70 @@
+from time import sleep
 import unittest
+from pulpcore.client.pulpcore import (ApiClient as CoreApiClient, Configuration,
+                                      TasksApi)
+from pulpcore.client.pulp_2to3_migration import (ApiClient as MigrationApiClient,
+                                                 MigrationPlansApi)
+
+
+def monitor_task(tasks_api, task_href):
+    """Polls the Task API until the task is in a completed state.
+
+    Prints the task details and a success or failure message. Exits on failure.
+
+    Args:
+        tasks_api (pulpcore.client.pulpcore.TasksApi): an instance of a configured TasksApi client
+        task_href(str): The href of the task to monitor
+
+    Returns:
+        list[str]: List of hrefs that identify resource created by the task
+
+    """
+    completed = ['completed', 'failed', 'canceled']
+    task = tasks_api.read(task_href)
+    while task.state not in completed:
+        sleep(2)
+        task = tasks_api.read(task_href)
+    if task.state == 'completed':
+        print("The task was successfful.")
+    else:
+        print("The task did not finish successfully.")
+    return task
 
 
 class TestMigrationPlan(unittest.TestCase):
     """Test the APIs for creating a Migration Plan."""
 
+    @classmethod
+    def setUpClass(cls):
+        """
+        Create all the client instances needed to communicate with Pulp.
+        """
+
+        configuration = Configuration()
+        configuration.username = 'admin'
+        configuration.password = 'password'
+        configuration.safe_chars_for_path_param = '/'
+
+        core_client = CoreApiClient(configuration)
+        # file_client = FileApiClient(configuration)
+        migration_client = MigrationApiClient(configuration)
+
+        # Create api clients for all resource types
+        # artifacts = ArtifactsApi(core_client)
+        # repositories = RepositoriesApi(core_client)
+        # repoversions = RepositoriesVersionsApi(core_client)
+        # filecontent = ContentFilesApi(file_client)
+        # filedistributions = DistributionsFileApi(core_client)
+        # filepublications = PublicationsFileApi(file_client)
+        # fileremotes = RemotesFileApi(file_client)
+        cls.tasks = TasksApi(core_client)
+        # uploads = UploadsApi(core_client)
+        cls.migration_plans = MigrationPlansApi(migration_client)
+
     def test_create_migration_plan(self):
         """Test that a valid Migration Plan can be created."""
-        self.assertTrue(True)
+        migration_plan = '{"plugins": [{"type": "iso"}]}'
+        mp = self.migration_plans.create({'plan': migration_plan})
+        mp_run_response = self.migration_plans.run(mp.pulp_href, data={})
+        task = monitor_task(self.tasks, mp_run_response.task)
+        self.assertEqual(task.state, "completed")

--- a/pulp_2to3_migration/tests/functional/test_file_migration.py
+++ b/pulp_2to3_migration/tests/functional/test_file_migration.py
@@ -1,3 +1,4 @@
+import socket
 from time import sleep
 import unittest
 from pulpcore.client.pulpcore import (ApiClient as CoreApiClient, Configuration,
@@ -43,6 +44,7 @@ class TestMigrationPlan(unittest.TestCase):
         configuration = Configuration()
         configuration.username = 'admin'
         configuration.password = 'password'
+        configuration.host = 'http://{}:24817'.format(socket.gethostname())
         configuration.safe_chars_for_path_param = '/'
 
         core_client = CoreApiClient(configuration)

--- a/pulp_2to3_migration/tests/functional/test_file_migration.py
+++ b/pulp_2to3_migration/tests/functional/test_file_migration.py
@@ -1,0 +1,9 @@
+import unittest
+
+
+class TestMigrationPlan(unittest.TestCase):
+    """Test the APIs for creating a Migration Plan."""
+
+    def test_create_migration_plan(self):
+        """Test that a valid Migration Plan can be created."""
+        self.assertTrue(True)

--- a/pulp_2to3_migration/tests/functional/test_file_migration.py
+++ b/pulp_2to3_migration/tests/functional/test_file_migration.py
@@ -1,14 +1,21 @@
 import socket
 from time import sleep
 import unittest
-from pulpcore.client.pulpcore import (ApiClient as CoreApiClient, Configuration,
-                                      TasksApi)
-from pulpcore.client.pulp_file import (ApiClient as FileApiClient,
-                                       ContentFilesApi,
-                                       RepositoriesFileApi,
-                                       RepositoriesFileVersionsApi)
-from pulpcore.client.pulp_2to3_migration import (ApiClient as MigrationApiClient,
-                                                 MigrationPlansApi)
+from pulpcore.client.pulpcore import (
+    ApiClient as CoreApiClient,
+    Configuration,
+    TasksApi
+)
+from pulpcore.client.pulp_file import (
+    ApiClient as FileApiClient,
+    ContentFilesApi,
+    RepositoriesFileApi,
+    RepositoriesFileVersionsApi
+)
+from pulpcore.client.pulp_2to3_migration import (
+    ApiClient as MigrationApiClient,
+    MigrationPlansApi
+)
 from pulp_2to3_migration.pulp2.base import Repository as Pulp2Repository, RepositoryContentUnit
 from pulp_2to3_migration.pulp2.connection import initialize
 
@@ -64,27 +71,22 @@ class TestMigrationPlan(unittest.TestCase):
         migration_client = MigrationApiClient(configuration)
 
         # Create api clients for all resource types
-        # artifacts = ArtifactsApi(core_client)
-        cls.file_repositories = RepositoriesFileApi(file_client)
-        cls.file_repo_versions = RepositoriesFileVersionsApi(file_client)
-        cls.file_content = ContentFilesApi(file_client)
-        # filedistributions = DistributionsFileApi(core_client)
-        # filepublications = PublicationsFileApi(file_client)
-        # fileremotes = RemotesFileApi(file_client)
-        cls.tasks = TasksApi(core_client)
-        # uploads = UploadsApi(core_client)
-        cls.migration_plans = MigrationPlansApi(migration_client)
+        cls.file_repo_api = RepositoriesFileApi(file_client)
+        cls.file_repo_versions_api = RepositoriesFileVersionsApi(file_client)
+        cls.file_content_api = ContentFilesApi(file_client)
+        cls.tasks_api = TasksApi(core_client)
+        cls.migration_plans_api = MigrationPlansApi(migration_client)
 
     def test_migrate_iso_repositories(self):
-        """Test that a valid Migration Plan can be created."""
+        """Test that a Migration Plan to migrate ISO content executes correctly."""
         migration_plan = '{"plugins": [{"type": "iso"}]}'
-        mp = self.migration_plans.create({'plan': migration_plan})
-        mp_run_response = self.migration_plans.run(mp.pulp_href, data={})
-        task = monitor_task(self.tasks, mp_run_response.task)
+        mp = self.migration_plans_api.create({'plan': migration_plan})
+        mp_run_response = self.migration_plans_api.run(mp.pulp_href, data={})
+        task = monitor_task(self.tasks_api, mp_run_response.task)
         self.assertEqual(task.state, "completed")
         pulp2repositories = Pulp2Repository.objects.all()
         for pulp2repo in pulp2repositories:
-            pulp3repos = self.file_repositories.list(name=pulp2repo.repo_id)
+            pulp3repos = self.file_repo_api.list(name=pulp2repo.repo_id)
             repo_href = pulp3repos.results[0].pulp_href
             self.failIf(not pulp3repos.results,
                         "Missing a Pulp 3 repository for Pulp 2 "
@@ -93,7 +95,7 @@ class TestMigrationPlan(unittest.TestCase):
             self.assertEqual(pulp2repo.repo_id, pulp3repos.results[0].name)
             # Assert that there is a Repository Version with the same number of content units as
             # associated with the repository in Pulp 2.
-            repo_version_href = self.file_repo_versions.list(repo_href).results[0].pulp_href
+            repo_version_href = self.file_repo_versions_api.list(repo_href).results[0].pulp_href
             pulp2_repo_content = RepositoryContentUnit.objects.filter(repo_id=pulp2repo.repo_id)
-            repo_version_content = self.file_content.list(repository_version=repo_version_href)
+            repo_version_content = self.file_content_api.list(repository_version=repo_version_href)
             self.assertEqual(pulp2_repo_content.count(), repo_version_content.count)

--- a/pulp_2to3_migration/tests/functional/test_nothing.py
+++ b/pulp_2to3_migration/tests/functional/test_nothing.py
@@ -1,9 +1,0 @@
-import unittest
-
-
-class TestNothing(unittest.TestCase):
-    """Test Nothing (placeholder)."""
-
-    def test_nothing_at_all(self):
-        """Test that the tests are running and that's it."""
-        self.assertTrue(True)

--- a/template_config.yml
+++ b/template_config.yml
@@ -22,7 +22,7 @@ plugin_dash: pulp-2to3-migration
 plugin_dash_short: 2to3-migration
 plugin_name: pulp-2to3-migration
 plugin_snake: pulp_2to3_migration
-pulp_settings: null
+pulp_settings:
 pydocstyle: false
 pypi_username: pulp
 test_bindings: true

--- a/template_config.yml
+++ b/template_config.yml
@@ -25,7 +25,7 @@ plugin_snake: pulp_2to3_migration
 pulp_settings:
 pydocstyle: false
 pypi_username: pulp
-test_bindings: true
+test_bindings: false
 test_performance: false
 travis_notifications:
   irc:


### PR DESCRIPTION
Install MongoDB on Travis
Build bindings for pulpcore and the migration plugin
Clone https://github.com/pulp/pulp-2to3-migration-test-fixtures
Populate MongoDB and /var/lib/pulp using the fixtures repo
Run a test that creates a migration plan and runs it. 