### PR TITLE
Use `BaseModel` instead of `Model`

### DIFF
--- a/CHANGES/5693.misc
+++ b/CHANGES/5693.misc
@@ -1,0 +1,1 @@
+Use `BaseModel` instead of `Model`.

--- a/pulp_2to3_migration/app/models/base.py
+++ b/pulp_2to3_migration/app/models/base.py
@@ -1,6 +1,6 @@
 from django.contrib.postgres.fields import JSONField
 
-from pulpcore.plugin.models import Model
+from pulpcore.plugin.models import BaseModel
 
 from pulp_2to3_migration.pulp2 import connection
 from pulp_2to3_migration.pulp2.base import (
@@ -10,7 +10,7 @@ from pulp_2to3_migration.pulp2.base import (
 )
 
 
-class MigrationPlan(Model):
+class MigrationPlan(BaseModel):
     """
     Migration Plans that have been created and maybe even run.
 

--- a/pulp_2to3_migration/app/models/content.py
+++ b/pulp_2to3_migration/app/models/content.py
@@ -1,10 +1,10 @@
 from django.db import models
 
 from pulpcore.app.models import Content  # it has to be imported directly from pulpcore see #5353
-from pulpcore.plugin.models import Model
+from pulpcore.plugin.models import BaseModel
 
 
-class Pulp2Content(Model):
+class Pulp2Content(BaseModel):
     """
     General info about Pulp 2 content.
 
@@ -36,7 +36,7 @@ class Pulp2Content(Model):
         return getattr(self, f'{self.pulp2_content_type_id}_detail_model').get()
 
 
-class Pulp2to3Content(Model):
+class Pulp2to3Content(BaseModel):
     """
     Pulp 2to3 detail content model to store pulp 2 content details for Pulp 3 content creation.
     """
@@ -77,7 +77,7 @@ class Pulp2to3Content(Model):
         raise NotImplementedError()
 
 
-class Pulp2LazyCatalog(Model):
+class Pulp2LazyCatalog(BaseModel):
     """
     Information for downloading Pulp 2 on_demand content.
 

--- a/pulp_2to3_migration/app/models/repository.py
+++ b/pulp_2to3_migration/app/models/repository.py
@@ -5,14 +5,14 @@ from pulpcore.app.models import (  # it has to be imported directly from pulpcor
     Remote,
 )
 from pulpcore.plugin.models import (
-    Model,
+    BaseModel,
     BaseDistribution,
     RepositoryVersion,
     Publication,
 )
 
 
-class Pulp2Repository(Model):
+class Pulp2Repository(BaseModel):
     """
     Information about Pulp 2 repository.
 
@@ -45,7 +45,7 @@ class Pulp2Repository(Model):
                                                     null=True)
 
 
-class Pulp2RepoContent(Model):
+class Pulp2RepoContent(BaseModel):
     """
     Information about content in Pulp 2 repository.
 
@@ -69,7 +69,7 @@ class Pulp2RepoContent(Model):
         unique_together = ('pulp2_repository', 'pulp2_unit_id')
 
 
-class Pulp2Importer(Model):
+class Pulp2Importer(BaseModel):
     """
     Information about Pulp 2 importer.
 
@@ -95,7 +95,7 @@ class Pulp2Importer(Model):
     pulp3_remote = models.OneToOneField(Remote, on_delete=models.SET_NULL, null=True)
 
 
-class Pulp2Distributor(Model):
+class Pulp2Distributor(BaseModel):
     """
     Information about Pulp 2 distributor.
 


### PR DESCRIPTION
pulpcore changed the name of `Model` to `BaseModel`. This PR updates
pulp-2to3-migration to do the same.

Required PR: https://github.com/pulp/pulpcore/pull/421

https://pulp.plan.io/issues/5693
closes #5693