### PR TITLE
Problem: pulp-2to3-migration CI often fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@
 ---
 sudo: required
 # https://docs.travis-ci.com/user/trusty-ci-environment/
-dist: xenial
+dist: bionic
 language: python
 python:
   # Fedora has 3.6 available (python36.x86_64), but pulp container images
@@ -21,6 +21,7 @@ services:
   - postgresql
   - redis-server
   - docker
+  # This line manually added until the plugin-template makes this configurable.
   - mongodb
 addons:
   apt:
@@ -52,28 +53,33 @@ jobs:
     # https://github.com/travis-ci/travis-ci/issues/8536
     # https://github.com/travis-ci/travis-ci/issues/4681
     - stage: test
-    - stage: deploy-plugin-to-pypi
+    - stage: deploy
+      name: "Deploy plugin to pypi"
       before_install: skip
       install: skip
       before_script: skip
       script: bash .travis/publish_plugin_pypi.sh
       if: tag IS present
-    - stage: publish-daily-client-gem
+    - stage: deploy
+      name: "Publish client to rubygems"
       script: bash .travis/publish_client_gem.sh
       env:
         - TEST=bindings
       if: type = cron
-    - stage: publish-daily-client-pypi
+    - stage: deploy
+      name: "Publish client to pypi"
       script: bash .travis/publish_client_pypi.sh
       env:
         - TEST=bindings
       if: type = cron
-    - stage: publish-client-gem
+    - stage: deploy
+      name: "Publish client to rubygems"
       script: bash .travis/publish_client_gem.sh
       env:
         - TEST=bindings
       if: tag IS present
-    - stage: publish-client-pypi
+    - stage: deploy
+      name: "Publish client to pypi"
       script: bash .travis/publish_client_pypi.sh
       env:
         - TEST=bindings

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -24,21 +24,19 @@ if [[ -n $(echo -e $COMMIT_MSG | grep -P "Required PR:.*" | grep -v "https") ]];
   exit 1
 fi
 
-if [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ -z "$TRAVIS_TAG" -a "$TRAVIS_BRANCH" != "master"]
+if [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ -z "$TRAVIS_TAG" -a "$TRAVIS_BRANCH" != "master" ]
 then
   export PULP_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulpcore\/pull\/(\d+)' | awk -F'/' '{print $7}')
   export PULP_SMASH_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp-smash\/pull\/(\d+)' | awk -F'/' '{print $7}')
   export PULP_ROLES_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/ansible-pulp\/pull\/(\d+)' | awk -F'/' '{print $7}')
   export PULP_BINDINGS_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp-openapi-generator\/pull\/(\d+)' | awk -F'/' '{print $7}')
   export PULP_OPERATOR_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp-operator\/pull\/(\d+)' | awk -F'/' '{print $7}')
-  export PULP_BINDINGS_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp-openapi-generator\/pull\/(\d+)' | awk -F'/' '{print $7}')
 else
   export PULP_PR_NUMBER=
   export PULP_SMASH_PR_NUMBER=
   export PULP_ROLES_PR_NUMBER=
   export PULP_BINDINGS_PR_NUMBER=
   export PULP_OPERATOR_PR_NUMBER=
-  export PULP_BINDINGS_PR_NUMBER=
 fi
 
 # dev_requirements contains tools needed for flake8, etc.
@@ -57,8 +55,8 @@ cd ..
 git clone --depth=1 https://github.com/pulp/ansible-pulp.git
 if [ -n "$PULP_ROLES_PR_NUMBER" ]; then
   cd ansible-pulp
-  git fetch --depth=1 origin +refs/pull/$PULP_ROLES_PR_NUMBER/merge
-  git checkout FETCH_HEAD
+  git fetch --depth=1 origin pull/$PULP_ROLES_PR_NUMBER/head:$PULP_ROLES_PR_NUMBER
+  git checkout $PULP_ROLES_PR_NUMBER
   cd ..
 fi
 
@@ -66,8 +64,8 @@ fi
 git clone --depth=1 https://github.com/pulp/pulp-operator.git
 if [ -n "$PULP_OPERATOR_PR_NUMBER" ]; then
   cd pulp-operator
-  git fetch --depth=1 origin +refs/pull/$PULP_OPERATOR_PR_NUMBER/merge
-  git checkout FETCH_HEAD
+  git fetch --depth=1 origin pull/$PULP_OPERATOR_PR_NUMBER/head:$PULP_OPERATOR_PR_NUMBER
+  git checkout $PULP_OPERATOR_PR_NUMBER
   RELEASE_VERSION=v0.9.0
   curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
   chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu && sudo mkdir -p /usr/local/bin/ && sudo cp operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/operator-sdk && rm operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
@@ -78,18 +76,18 @@ fi
 git clone https://github.com/pulp/pulp-openapi-generator.git
 if [ -n "$PULP_BINDINGS_PR_NUMBER" ]; then
   cd pulp-openapi-generator
-  git fetch origin +refs/pull/$PULP_BINDINGS_PR_NUMBER/merge
-  git checkout FETCH_HEAD
+  git fetch origin pull/$PULP_BINDINGS_PR_NUMBER/head:$PULP_BINDINGS_PR_NUMBER
+  git checkout $PULP_BINDINGS_PR_NUMBER
   cd ..
 fi
 
 
-git clone --depth=1 https://github.com/pulp/pulpcore.git
+git clone --depth=1 https://github.com/pulp/pulpcore.git --branch master
 
 if [ -n "$PULP_PR_NUMBER" ]; then
   cd pulpcore
-  git fetch --depth=1 origin +refs/pull/$PULP_PR_NUMBER/merge
-  git checkout FETCH_HEAD
+  git fetch --depth=1 origin pull/$PULP_PR_NUMBER/head:$PULP_PR_NUMBER
+  git checkout $PULP_PR_NUMBER
   cd ..
 fi
 
@@ -103,8 +101,8 @@ if [ -z "$TRAVIS_TAG" ]; then
 
   if [ -n "$PULP_SMASH_PR_NUMBER" ]; then
     cd pulp-smash
-    git fetch --depth=1 origin +refs/pull/$PULP_SMASH_PR_NUMBER/merge
-    git checkout FETCH_HEAD
+    git fetch --depth=1 origin pull/$PULP_SMASH_PR_NUMBER/head:$PULP_SMASH_PR_NUMBER
+    git checkout $PULP_SMASH_PR_NUMBER
     cd ..
   fi
 

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -31,6 +31,8 @@ else
     sed "s/localhost/$(hostname)/g" ../pulpcore/.travis/pulp-smash-config.json > ~/.config/pulp_smash/settings.json
 fi
 
+
+
 if [[ "$TEST" == 'pulp' || "$TEST" == 'performance' ]]; then
     # Many tests require pytest/mock, but users do not need them at runtime
     # (or to add plugins on top of pulpcore or pulp container images.)

--- a/.travis/cherrypick.py
+++ b/.travis/cherrypick.py
@@ -1,0 +1,121 @@
+import os
+import subprocess
+import uuid
+from git import Repo
+from github import Github
+from github.GithubException import UnknownObjectException
+
+PR_LABEL = "Needs Cherry Pick"
+STABLE_BRANCH = os.environ["STABLE_BRANCH"]
+REPOSITORY = os.environ["TRAVIS_REPO_SLUG"]
+GITHUB_USER = os.environ["GITHUB_USER"]
+GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+
+
+def blobs_match(commit1, commit2):
+    """Compare the file blobs of two commits."""
+    if len(commit1.files) != len(commit2.files):
+        return False
+
+    for cf in commit1.files:
+        files = [f for f in commit2.files if f.sha == cf.sha and f.filename == cf.filename]
+        if len(files) == 0:
+            return False
+
+    return True
+
+
+def get_merged_commits(pr):
+    """
+    Find the merged commits for a PR.
+
+    Github allows PRs to be merged with 3 different strategies: merge, rebase, and squashing. Github
+    doesn't record how a PR was merged in the API so we need to examine the merge commit to
+    determine how the pr was merged and then return the commits based on that.
+    """
+    merge_commit = pr.base.repo.get_commit(pr.merge_commit_sha)
+
+    if len(merge_commit.parents) > 1:
+        # PR was just merged and we can use the PR's commits
+        return pr.get_commits()
+    elif blobs_match(merge_commit, pr.get_commits().reversed[0]):
+        # if the last PR commit is the same as the merge commit then the PR was rebased
+        commits = []
+        commit = merge_commit
+        for _ in pr.get_commits():
+            if len(commit.parents) > 1:
+                print(f"Ran into problem attempting to cherry pick {commit.sha}.")
+                exit(1)
+            commits.append(commit)
+            commit = commit.parents[0]
+        commits.reverse()
+        return commits
+    else:
+        # we have a squashed commit. we can just use the merge commit
+        return [merge_commit]
+
+
+print(f"Processing cherry picks for {REPOSITORY}.")
+
+# prepare our local repo to receive git cherry picks
+repo = Repo(os.getcwd())
+remote_url = f"https://{GITHUB_USER}:{GITHUB_TOKEN}@github.com/{REPOSITORY}.git"
+remote = repo.create_remote("auth-origin", url=remote_url)
+remote.fetch()
+repo.git.checkout(STABLE_BRANCH)
+
+g = Github(GITHUB_TOKEN)
+grepo = g.get_repo(REPOSITORY)
+(label,) = (l for l in grepo.get_labels() if l.name == PR_LABEL)
+issues = grepo.get_issues(labels=[label], state="all")
+
+cherrypicks = []
+
+for issue in issues:
+    try:
+        pr = grepo.get_pull(issue.number)
+    except UnknownObjectException:
+        # this issue is not a PR. skip it.
+        continue
+
+    if not pr.merged:
+        print(f"Pull request {pr.number} not merged. Skipping.")
+        continue
+
+    print(f"Attempting to cherry-pick commits for {pr.html_url}.")
+
+    for commit in get_merged_commits(pr):
+        # looks like GitPython doesn't support cherry picks
+        ret = subprocess.run(["git", "cherry-pick", "-x", commit.sha], stderr=subprocess.PIPE)
+
+        if ret.returncode != 0:
+            print(f"Failed to cherry-pick commit {commit.sha}: {ret.stderr.decode('ascii')}")
+            exit(1)
+        else:
+            cherrypicks.append(issue)
+            print(f"Cherry-picked commit {commit.sha}.")
+
+# check if we cherry picked anything
+if len(cherrypicks) == 0:
+    print(f"No cherry picks detected.")
+    exit(0)
+
+# push our changes
+print(f"Attempting push changes to {REPOSITORY}.")
+cherry_pick_branch = f"cherry-picks-{uuid.uuid4()}"
+remote.push(refspec=f"{STABLE_BRANCH}:{cherry_pick_branch}")
+print(f"Pushed cherry picks to {cherry_pick_branch}.")
+
+# create a pull request
+body = f"Cherry picking #{(', #').join(str(cp.number) for cp in cherrypicks)}."
+pr = grepo.create_pull(f"Cherry picks to {STABLE_BRANCH}", body, STABLE_BRANCH, cherry_pick_branch)
+print(f"Created pull request {pr.html_url}.")
+
+# remove the cherry pick label from our PRs
+for cp in cherrypicks:
+    labels = cp.labels
+    labels.remove(label)
+    cp.edit(labels=labels)
+    print(f"Removed label '{PR_LABEL}' from PR #{cp.number}.")
+
+print("Cherry picking complete.")

--- a/.travis/cherrypick.sh
+++ b/.travis/cherrypick.sh
@@ -1,0 +1,5 @@
+pip install PyGithub GitPython yq
+
+export STABLE_BRANCH=$(yq -r ".stable_branch" template_config.yml)
+
+python ./.travis/cherrypick.py

--- a/.travis/post_before_script.sh
+++ b/.travis/post_before_script.sh
@@ -14,6 +14,10 @@ mongorestore --archive=pulp2filecontent.20191031.archive
 
 mongo pulp_database --eval 'db.createUser({user:"travis",pwd:"travis",roles:["readWrite"]});'
 
+# Otherwise, pulpcore will get installed as the stable release from PyPI
+# as a dep of pulp-2to3-migration.
+pip install $TRAVIS_BUILD_DIR/../pulpcore
+
 pip install .
 
 cd ../pulp-openapi-generator

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -34,10 +34,12 @@ fi
 
 if [ "$TEST" = 'bindings' ]; then
   cd ../pulp-openapi-generator
+  COMMIT_MSG=$(git log --format=%B --no-merges -1)
+  export PULP_BINDINGS_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp-openapi-generator\/pull\/(\d+)' | awk -F'/' '{print $7}')
 
   if [ -n "$PULP_BINDINGS_PR_NUMBER" ]; then
-    git fetch origin +refs/pull/$PULP_BINDINGS_PR_NUMBER/merge
-    git checkout FETCH_HEAD
+    git fetch origin pull/$PULP_BINDINGS_PR_NUMBER/head:$PULP_BINDINGS_PR_NUMBER
+    git checkout $PULP_BINDINGS_PR_NUMBER
   fi
 
   ./generate.sh pulpcore python
@@ -104,7 +106,7 @@ set -u
 
 if [[ "$TEST" == "performance" ]]; then
   echo "--- Performance Tests ---"
-  if [[ -z "$PERFORMANCE_TEST" ]]; then
+  if [[ -z ${PERFORMANCE_TEST+x} ]]; then
     pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 pulp_2to3_migration.tests.performance || show_logs_and_return_non_zero
   else
     pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 pulp_2to3_migration.tests.performance.test_$PERFORMANCE_TEST || show_logs_and_return_non_zero

--- a/CHANGES/6035.misc
+++ b/CHANGES/6035.misc
@@ -1,0 +1,1 @@
+Fix CI failures with pkg_resources.ContextualVersionConflict

--- a/template_config.yml
+++ b/template_config.yml
@@ -2,16 +2,18 @@
 # were not present before running plugin-template have been added with their default values.
 
 additional_plugins:
-- pulp_file
-- pulp_container
+- { name: pulp_file, branch: master }
+- { name: pulp_container, branch: master }
 black: false
 check_commit_message: true
+cherry_pick_automation: false
 coverage: false
 deploy_client_to_pypi: true
 deploy_client_to_rubygems: true
 deploy_daily_client_to_pypi: true
 deploy_daily_client_to_rubygems: true
 deploy_to_pypi: true
+docker_fixtures: false
 docs_test: false
 plugin_app_label: pulp_2to3_migration
 plugin_camel: Pulp-2To3-Migration
@@ -22,9 +24,11 @@ plugin_dash: pulp-2to3-migration
 plugin_dash_short: 2to3-migration
 plugin_name: pulp-2to3-migration
 plugin_snake: pulp_2to3_migration
-pulp_settings:
+pulp_settings: null
+pulpcore_branch: master
 pydocstyle: false
 pypi_username: pulp
+stable_branch: null
 test_bindings: false
 test_performance: false
 travis_notifications:


### PR DESCRIPTION
with pkg_resources.ContextualVersionConflict between pulpcore &
setuptools.

Solution: Regenerate with latest plugin template (so that pulpcore's
branch is configurable), and install pulpcore onto the Travis host
before pulp-2to3-migration gets installed.

Fixes: #6035
https://pulp.plan.io/issues/6035