### PR TITLE
Specifies pulpcore version explicitly in the install script

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -103,6 +103,7 @@ spec:
     size: "40Gi"
   image: pulp-2to3-migration
   tag: "${TAG}"
+  pulpcore: pulpcore~=3.0
   database_connection:
     username: pulp
     password: pulp


### PR DESCRIPTION
This is a temporary fix which will be made permanent when plugin template is updated.

[noissue]