### PR TITLE
Problem: plugin-template is out-of-date,

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -66,6 +66,7 @@ images:
   - pulp-2to3-migration-${TAG}:
       image_name: pulp-2to3-migration
       tag: $TAG
+      pulpcore: pulpcore~=3.0.0
       plugins:
         - ./pulp-2to3-migration
         - pulp_file~=0.1.0

--- a/template_config.yml
+++ b/template_config.yml
@@ -2,8 +2,8 @@
 # were not present before running plugin-template have been added with their default values.
 
 additional_plugins:
-- { name: pulp_file, branch: 0.1 }
-- { name: pulp_container, branch: 1.0 }
+- { name: pulp_file, branch: 0.1, pip_version_specifier: ~=0.1.0 }
+- { name: pulp_container, branch: 1.0, pip_version_specifier: ~=1.0.0 }
 black: false
 check_commit_message: true
 cherry_pick_automation: false
@@ -26,6 +26,7 @@ plugin_name: pulp-2to3-migration
 plugin_snake: pulp_2to3_migration
 pulp_settings: null
 pulpcore_branch: 3.0
+pulpcore_pip_version_specifier: ~=3.0.0
 pydocstyle: false
 pypi_username: pulp
 stable_branch: null


### PR DESCRIPTION
and we had to put hardcoded workarounds for its lack of functionality.

Solution: Use the latest plugin-template with values specified.

re: #6149
Problem: Plugins during Travis tag/release jobs always install the latest PyPI releases of pulpcore & other plugins
https://pulp.plan.io/issues/6149