### PR TITLE
Rename type to TYPE_ID on pulp 2 content models.

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,12 +180,12 @@ from Pulp 2 to Pulp 3, here are some guidelines.
  to the list of the "migrators" entry_points in setup.py.
 
 3. Add a Content model to communicate with Pulp 2.
- - It has to have a field `pulp2_type` which will correspond to the `_content_type_id` of your Content
- in Pulp 2. Don't forget to add it to `content_models` in step 1.
+ - It has to have a field `TYPE_ID` which will correspond to the `_content_type_id` of your Content
+ in Pulp 2. Don't forget to add it to `pulp2_content_models` in step 1.
 
 4. Add a Content model to pre-migrate Pulp 2 content to (subclass the provided `Pulp2to3Content`
 class). It has to have:
- - a field `type` which will correspond to the `_content_type_id` of your Content in Pulp 2.
+ - a field `pulp2_type` which will correspond to the `_content_type_id` of your Content in Pulp 2.
  - on a Meta class a `default_related_name` set to `<your pulp 2 content type>_detail_model`
  - a classmethod `pre_migrate_content_detail` (see `Pulp2to3Content` for more details)
  - a method `create_pulp3_content` (see `Pulp2to3Content` for more details)

--- a/pulp_2to3_migration/app/plugin/docker/pulp2_models.py
+++ b/pulp_2to3_migration/app/plugin/docker/pulp2_models.py
@@ -28,7 +28,7 @@ class Blob(FileContentUnit):
     unit_display_name = 'docker blob'
     unit_description = 'docker blob'
 
-    type = 'docker_blob'
+    TYPE_ID = 'docker_blob'
 
     meta = {
         'collection': 'units_docker_blob',
@@ -62,7 +62,7 @@ class Manifest(FileContentUnit):
     unit_display_name = 'docker manifest'
     unit_description = 'docker manifest'
 
-    type = 'docker_manifest'
+    TYPE_ID = 'docker_manifest'
 
     meta = {
         'collection': 'units_docker_manifest',
@@ -97,7 +97,7 @@ class ManifestList(FileContentUnit):
     unit_display_name = 'docker manifest list'
     unit_description = 'docker manifest list'
 
-    type = 'docker_manifest_list'
+    TYPE_ID = 'docker_manifest_list'
 
     meta = {
         'collection': 'units_docker_manifest_list',
@@ -121,7 +121,7 @@ class Tag(ContentUnit):
     unit_display_name = 'docker tag'
     unit_description = 'docker tag'
 
-    type = 'docker_tag'
+    TYPE_ID = 'docker_tag'
 
     meta = {
         'collection': 'units_docker_tag',

--- a/pulp_2to3_migration/app/plugin/iso/pulp2_models.py
+++ b/pulp_2to3_migration/app/plugin/iso/pulp2_models.py
@@ -27,7 +27,7 @@ class ISO(FileContentUnit):
     unit_display_name = 'ISO'
     unit_description = 'ISO'
 
-    type = 'iso'
+    TYPE_ID = 'iso'
 
     meta = {
         'collection': 'units_iso',

--- a/pulp_2to3_migration/app/pre_migration.py
+++ b/pulp_2to3_migration/app/pre_migration.py
@@ -67,7 +67,7 @@ async def pre_migrate_content(content_model):
         content_model: Models for content which is being migrated.
     """
     batch_size = 10000
-    content_type = content_model.pulp2.type
+    content_type = content_model.pulp2.TYPE_ID
     pulp2content = []
 
     # the latest timestamp we have in the migration tool Pulp2Content table for this content type


### PR DESCRIPTION
Some pulp 2 content models have `type` field as a part of a model and it conflicts with this attribute.
Some pulp 2 models have already TYPE_ID defined, thus the suggestion to rename to it.

[noissue]