### PR TITLE
Problem: Migrating large repository leads to unmigrated units.

### DIFF
--- a/CHANGES/6103.bugfix
+++ b/CHANGES/6103.bugfix
@@ -1,0 +1,1 @@
+Migrating large repository leads to unmigrated units.


### PR DESCRIPTION
Solution: Remove slicing of the unevaluated qs.

closes #6103
https://pulp.plan.io/issues/6103