### PR TITLE
Add optional migrator attributes to base class, adjust batch size.

### DIFF
--- a/pulp_2to3_migration/app/plugin/iso/migrator.py
+++ b/pulp_2to3_migration/app/plugin/iso/migrator.py
@@ -35,16 +35,12 @@ class IsoMigrator(Pulp2to3PluginMigrator):
     content_models = {
         'iso': Pulp2ISO,
     }
-
-    mutable_content_models = {}
     importer_migrators = {
         'iso_importer': IsoImporter,
     }
     distributor_migrators = {
         'iso_distributor': IsoDistributor,
     }
-
-    premigrate_hook = {}
 
     @classmethod
     async def migrate_content_to_pulp3(cls):

--- a/pulp_2to3_migration/app/plugin/migrator.py
+++ b/pulp_2to3_migration/app/plugin/migrator.py
@@ -12,11 +12,17 @@ class Pulp2to3PluginMigrator:
         pulp3_plugin(str): Pulp 3 plugin name
         pulp3_repository(class): Pulp 3 Repository model
         content_models(dict): {'pulp2 content_type_id': 'detail content class to pre-migrate to'}
-        mutable_content_models(dict): {'content_type_id': 'detail content class to pre-migrate to'}
+        mutable_content_models(dict): {'content_type_id': 'detail content class to pre-migrate to'}.
+                                      Optional.
         importer_migrators(dict): {'importer_type_id': 'pulp_2to3 importer interface/migrator'}
         distributor_migrators(dict): {'distributor_type_id': 'pulp_2to3 dist interface/migrator'}
+        premigrate_hook(dict): {'content_type_id': 'a callback to determine units to premigrate'}.
+                               Optional.
 
     """
+    mutable_content_models = {}
+    premigrate_hook = {}
+
     @classmethod
     async def migrate_to_pulp3(cls):
         """

--- a/pulp_2to3_migration/app/pre_migration.py
+++ b/pulp_2to3_migration/app/pre_migration.py
@@ -73,7 +73,7 @@ async def pre_migrate_content(content_model, mutable_type, premigrate_hook):
         content_model: Models for content which is being migrated.
         mutable_type: Boolean that indicates whether the content type is mutable.
     """
-    batch_size = 10000
+    batch_size = 1000
     content_type = content_model.pulp2.TYPE_ID
     pulp2content = []
     pulp2mutatedcontent = []


### PR DESCRIPTION
Plugins should not be required to  define attributes
which are of no use for their migrator.

The batch size is adjusted to avoid high memory consumption,
it's especially noticeable  for RPM packages migtation.

[noissue]