### PR TITLE
Ensure that only one migration plan can be run at a time.

### DIFF
--- a/CHANGES/6639.bugfix
+++ b/CHANGES/6639.bugfix
@@ -1,0 +1,1 @@
+Ensure that only one migration plan can be run at a time.


### PR DESCRIPTION
closes #6639
https://pulp.plan.io/issues/6639