### PR TITLE
Consider all repos present in the plan, not only the ones to migrate.

### DIFF
--- a/CHANGES/6853.bugfix
+++ b/CHANGES/6853.bugfix
@@ -1,0 +1,1 @@
+Fixed distribution creation when a distributor is from a repo which is not being migrated.

--- a/pulp_2to3_migration/app/tasks/migrate.py
+++ b/pulp_2to3_migration/app/tasks/migrate.py
@@ -65,7 +65,9 @@ def migrate_from_pulp2(migration_plan_pk, validate=False, dry_run=False):
             for content_type in plugin.migrator.pulp2_content_models:
                 content_type_to_plugin[content_type] = plugin.migrator.pulp2_plugin
 
-            repos = plugin.get_repositories()
+            repos = set(plugin.get_repositories())
+            repos |= set(plugin.get_importers_repos())
+            repos |= set(plugin.get_distributors_repos())
 
             for repo in repos:
                 repo_id_to_type[repo] = plugin.type


### PR DESCRIPTION
We need to go through all repos mentioned in the plan
in case importers' or distributors' repos are not being migrated.
Otherwise, such importers and distributors are ignored and not migrated.

closes #6853
https://pulp.plan.io/issues/6853