### PR TITLE
Set pulp3_repo relation for all the cases, including remigration.

### DIFF
--- a/CHANGES/6640.bugfix
+++ b/CHANGES/6640.bugfix
@@ -1,0 +1,1 @@
+Fixed `UnboundLocalError` during migration of a repo with a custom name.

--- a/CHANGES/6964.bugfix
+++ b/CHANGES/6964.bugfix
@@ -1,0 +1,1 @@
+Set pulp3_repo relation for all the cases, including remigration.

--- a/CHANGES/6966.bugfix
+++ b/CHANGES/6966.bugfix
@@ -1,0 +1,1 @@
+Fixed incorrect pulp3_repo_version href for advisories after remigration.


### PR DESCRIPTION
As a side effect, also fixes the case when a repo name differs from the pulp2 one.

closes #6964
https://pulp.plan.io/issues/6964

closes #6640
https://pulp.plan.io/issues/6640

closes #6966
https://pulp.plan.io/issues/6966