### PR TITLE
Stop generating bindings in the post_before_script.

### DIFF
--- a/.travis/post_before_script.sh
+++ b/.travis/post_before_script.sh
@@ -20,11 +20,3 @@ pip install $TRAVIS_BUILD_DIR/../pulpcore
 
 pip install .
 
-cd ../pulp-openapi-generator
-
-./generate.sh pulpcore python
-pip install ./pulpcore-client
-./generate.sh pulp_file python
-pip install ./pulp_file-client
-./generate.sh pulp_2to3_migration python
-pip install ./pulp_2to3_migration-client

--- a/CHANGES/7016.bugfix
+++ b/CHANGES/7016.bugfix
@@ -1,0 +1,1 @@
+Fixed Ruby bindings generation.


### PR DESCRIPTION
Bindings are already correctly generated as a part of script.sh.

closes #7016
https://pulp.plan.io/issues/7016