### PR TITLE
Fix a bug with multiple copies of an errata end up in a repo

### DIFF
--- a/CHANGES/7165.bugfix
+++ b/CHANGES/7165.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where migrated repositories could have multiple different copies of an errata.

--- a/pulp_2to3_migration/app/migration.py
+++ b/pulp_2to3_migration/app/migration.py
@@ -350,8 +350,11 @@ def create_repo_version(migrator, progress_rv, pulp2_repo, pulp3_remote=None):
     pulp3_repo = pulp2_repo.pulp3_repository
     unit_ids = Pulp2RepoContent.objects.filter(pulp2_repository=pulp2_repo).values_list(
         'pulp2_unit_id', flat=True)
-    incoming_content = set(Pulp2Content.objects.filter(pulp2_id__in=unit_ids).only(
-        'pulp3_content').values_list('pulp3_content__pk', flat=True))
+    incoming_content = set(
+        Pulp2Content.objects.filter(
+            pulp2_id__in=unit_ids, pulp2_repo=pulp2_repo
+        ).only('pulp3_content').values_list('pulp3_content__pk', flat=True)
+    )
 
     with pulp3_repo.new_version() as new_version:
         repo_content = set(new_version.content.values_list('pk', flat=True))

--- a/pulp_2to3_migration/app/migration.py
+++ b/pulp_2to3_migration/app/migration.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.db.models import F
+from django.db.models import F, Q
 
 from pulpcore.plugin.models import (
     Content,
@@ -352,7 +352,7 @@ def create_repo_version(migrator, progress_rv, pulp2_repo, pulp3_remote=None):
         'pulp2_unit_id', flat=True)
     incoming_content = set(
         Pulp2Content.objects.filter(
-            pulp2_id__in=unit_ids, pulp2_repo=pulp2_repo
+            Q(pulp2_id__in=unit_ids) & (Q(pulp2_repo=None) | Q(pulp2_repo=pulp2_repo)),
         ).only('pulp3_content').values_list('pulp3_content__pk', flat=True)
     )
 

--- a/pulp_2to3_migration/app/plugin/content.py
+++ b/pulp_2to3_migration/app/plugin/content.py
@@ -220,6 +220,7 @@ class ContentMigrationFirstStage(Stage):
         is_artifactless_type = content_type in migrator.artifactless_types
         has_future = content_type in migrator.future_types
         is_multi_artifact = content_type in migrator.multi_artifact_types
+
         for pulp_2to3_detail_content in batch:
             dc = None
             pulp2content = pulp_2to3_detail_content.pulp2content


### PR DESCRIPTION
The packagelist of an errata depends on content within the repo. When an
errata is copied from one Pulp 2 repository to another, it is the same
content unit but with a different package list, but in Pulp 3 these
would be considered separate content units.

Because of this, when content is migrated, two Pulp 3 UpdateRecords are
created from the same Pulp2Content. Later when content units are
associated with the repositories, no accounting was being taken for the
fact that this could be the case, and that we needed to pick the
particular content unit of the form that existed in the Pulp 2
repository rather than all of them.ul

re: #7165
https://pulp.plan.io/issues/7165