### PR TITLE
Fix a bug where errata were not always migrated for new repositories

### DIFF
--- a/CHANGES/7092.bugfix
+++ b/CHANGES/7092.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where errata were not always migrated for new repositories.

--- a/pulp_2to3_migration/app/tasks/migrate.py
+++ b/pulp_2to3_migration/app/tasks/migrate.py
@@ -132,9 +132,9 @@ def migrate_from_pulp2(migration_plan_pk, validate=False, dry_run=False):
     # TODO: if plan is empty for a plugin, only migrate downloaded content
 
     pre_migrate_all_without_content(plan, type_to_repo_ids, repo_id_to_type)
+    pre_migrate_all_content(plan)
     mark_removed_resources(plan, type_to_repo_ids)
     delete_old_resources(plan)
-    pre_migrate_all_content(plan)
     migrate_repositories(plan)
     migrate_importers(plan)
     migrate_content(plan)


### PR DESCRIPTION
If an errata has already been migrated and is then added to a new
repository, which is then migrated, the new repository does not contain
the affected errata.

Ensure that new Pulp2Content are created when existing content are
migrated into new repos for the errata corner case (needs one per each repo).

closes: #7092
https://pulp.plan.io/issues/7092