### PR TITLE
Fix distribution tree migration due to recent changes in the RPM plugin.

### DIFF
--- a/CHANGES/6950.bugfix
+++ b/CHANGES/6950.bugfix
@@ -1,0 +1,1 @@
+Fixed distribution tree migration when a distribution tree is present in multiple repositories.

--- a/CHANGES/7206.misc
+++ b/CHANGES/7206.misc
@@ -1,0 +1,1 @@
+Fix distribution tree migration issues caused by the model changes in the RPM plugin.


### PR DESCRIPTION
Also fixes the case when a distribution tree is present in multiple repos.

closes #7206
https://pulp.plan.io/issues/7206

closes #6950
https://pulp.plan.io/issues/6950