### PR TITLE
Don't iterate all lazy content every time we re-migrate

### DIFF
--- a/CHANGES/6111.bugfix
+++ b/CHANGES/6111.bugfix
@@ -1,0 +1,1 @@
+Significantly improved performance of partial migrations (when some content / repos has been migrated already).

--- a/pulp_2to3_migration/app/pre_migration.py
+++ b/pulp_2to3_migration/app/pre_migration.py
@@ -3,10 +3,7 @@ import logging
 from collections import namedtuple
 
 from django.db import transaction
-from django.db.models import (
-    Max,
-    Q,
-)
+from django.db.models import Max, Q
 from django.utils import timezone
 
 from mongoengine.queryset.visitor import Q as mongo_Q
@@ -264,7 +261,7 @@ def pre_migrate_lazycatalog(content_type):
         save_batch = (i and not (i + 1) % batch_size or i == total_lce - 1)
         if save_batch:
             Pulp2LazyCatalog.objects.bulk_create(pulp2lazycatalog, ignore_conflicts=True)
-            pulp2lazycatalog = []
+            pulp2lazycatalog.clear()
 
 
 def pre_migrate_all_without_content(plan, type_to_repo_ids, repo_id_to_type):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+django-cursor-pagination
 pulpcore>=3.4
 mongoengine
 semantic_version


### PR DESCRIPTION
Push some of our Python-level checks into database query logic to
significantly reduce the # of individual queries we make and the amount
of content we need to iterate over / prefetch for.

[noissue]