### PR TITLE
Fixed migration of a distribution tree if it has a treeinfo and not .…

### DIFF
--- a/CHANGES/6951.bugfix
+++ b/CHANGES/6951.bugfix
@@ -1,0 +1,1 @@
+Fixed migration of a distribution tree if it has a treeinfo and not .treeinfo

--- a/pulp_2to3_migration/app/plugin/rpm/pulp_2to3_models.py
+++ b/pulp_2to3_migration/app/plugin/rpm/pulp_2to3_models.py
@@ -714,7 +714,7 @@ class Pulp2Distribution(Pulp2to3Content):
         for namespace in namespaces:
             treeinfo = PulpTreeInfo()
             try:
-                treeinfo.load(f=os.path.join(self.pulp2content.pulp2_storage_path, '.treeinfo'))
+                treeinfo.load(f=os.path.join(self.pulp2content.pulp2_storage_path, namespace))
             except FileNotFoundError:
                 continue
             self.filename = namespace


### PR DESCRIPTION
…treenfo

closes #6951

https://pulp.plan.io/issues/6951