### PR TITLE
Set stable branch to 0.3 and unpin versions on master branch.

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -71,15 +71,15 @@ image:
   tag: "${TAG}"
 plugins:
   - name: pulpcore
-    source: pulpcore~=3.6.0
+    source: pulpcore
   - name: pulp-2to3-migration
     source: ./pulp-2to3-migration
   - name: pulp_file
-    source: pulp_file~=1.2.0
+    source: pulp_file
   - name: pulp_container
-    source: pulp_container~=2.0.0
+    source: pulp_container
   - name: pulp_rpm
-    source: pulp_rpm~=3.6.0
+    source: pulp_rpm
 services:
   - name: pulp
     image: "pulp:${TAG}"

--- a/template_config.yml
+++ b/template_config.yml
@@ -4,13 +4,10 @@
 additional_plugins:
 - branch: master
   name: pulp_file
-  pip_version_specifier: ~=1.2.0
 - branch: master
   name: pulp_container
-  pip_version_specifier: ~=2.0.0
 - branch: master
   name: pulp_rpm
-  pip_version_specifier: ~=3.6.0
 black: false
 check_commit_message: true
 cherry_pick_automation: true
@@ -33,11 +30,11 @@ plugin_name: pulp-2to3-migration
 plugin_snake: pulp_2to3_migration
 pulp_settings: null
 pulpcore_branch: master
-pulpcore_pip_version_specifier: ~=3.6.0
+pulpcore_pip_version_specifier: null
 pydocstyle: false
 pypi_username: pulp
 redmine_project: null
-stable_branch: '0.2'
+stable_branch: '0.3'
 test_bindings: false
 test_performance: false
 test_s3: false


### PR DESCRIPTION
pip versions are unset, so they are not accidentaly used with the next release.

[noissue]