### PR TITLE
Fix metadata checksum type re-migration when pulp 2 distributor changed.

### DIFF
--- a/CHANGES/7417.bugfix
+++ b/CHANGES/7417.bugfix
@@ -1,0 +1,1 @@
+Fixed metadata checksum type configuration re-migration.

--- a/pulp_2to3_migration/app/plugin/rpm/repository.py
+++ b/pulp_2to3_migration/app/plugin/rpm/repository.py
@@ -100,9 +100,10 @@ class RpmDistributor(Pulp2to3Distributor):
 
         """
         new_checksum_type = pulp2distributor.pulp2_config.get('checksum_type')
-        current_checksum_type = pulp2distributor.pulp3_publication.metadata_checksum_type
+        current_checksum_type = pulp2distributor.pulp3_publication.cast().metadata_checksum_type
 
-        if new_checksum_type != current_checksum_type:
+        is_default_checksum_type = new_checksum_type is None and current_checksum_type == 'sha256'
+        if new_checksum_type != current_checksum_type and not is_default_checksum_type:
             return True
 
         return False


### PR DESCRIPTION
Also keep re-migration no-op if the default checksum should be used.

closes #7417
https://pulp.plan.io/issues/7417