### PR TITLE
Do not set is_migrated=False for LCE when importer is being re-migrated.

### DIFF
--- a/CHANGES/7418.bugfix
+++ b/CHANGES/7418.bugfix
@@ -1,0 +1,1 @@
+Fixed re-migration issue when pulp 2 importer changed a feed.

--- a/pulp_2to3_migration/app/pre_migration.py
+++ b/pulp_2to3_migration/app/pre_migration.py
@@ -425,13 +425,8 @@ def pre_migrate_importer(repo_id, importers, importer_types, repo=None):
             if importer.pulp2_config.get('feed') != importer_data.config.get('feed'):
                 importer.pulp3_remote.delete()
                 importer.pulp3_remote = None
-                # find LCEs
-                pulp2lazycatalog = Pulp2LazyCatalog.objects.filter(
-                    pulp2_importer_id=importer.pulp2_object_id)
-                for lce in pulp2lazycatalog:
-                    lce.is_migrated = False
-                Pulp2LazyCatalog.objects.bulk_update(objs=pulp2lazycatalog,
-                                                     fields=['is_migrated'])
+                # do not flip is_migrated to False for LCE for at least once migrated importer
+
             importer.pulp2_last_updated = last_updated
             importer.pulp2_config = importer_data.config
             importer.is_migrated = False


### PR DESCRIPTION
closes #7418
https://pulp.plan.io/issues/7418

Some already migrated LCE might not exist in Pulp 2 anymore, trying to migrate those causes issues.
Identifying old ones is not easy, because htere are no timestamps in pulp 2 for lazy catalog.