### PR TITLE
Optimize content migration queries to avoid sorts

### DIFF
--- a/CHANGES/7699.bugfix
+++ b/CHANGES/7699.bugfix
@@ -1,0 +1,1 @@
+Made content migration significantly faster on low-spec machines w/ HDD backed database storage.

--- a/pulp_2to3_migration/app/tasks/migrate.py
+++ b/pulp_2to3_migration/app/tasks/migrate.py
@@ -10,8 +10,7 @@ from pulpcore.plugin.models import (
 )
 
 from pulp_2to3_migration.app.pre_migration import (
-    delete_old_resources,
-    mark_removed_resources,
+    handle_outdated_resources,
     pre_migrate_all_content,
     pre_migrate_all_without_content,
 )
@@ -134,8 +133,7 @@ def migrate_from_pulp2(migration_plan_pk, validate=False, dry_run=False):
 
     pre_migrate_all_without_content(plan, type_to_repo_ids, repo_id_to_type)
     pre_migrate_all_content(plan)
-    mark_removed_resources(plan, type_to_repo_ids)
-    delete_old_resources(plan)
+    handle_outdated_resources(plan, type_to_repo_ids)
     migrate_repositories(plan)
     migrate_importers(plan)
     migrate_content(plan)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-django-cursor-pagination
 pulpcore>=3.6
 mongoengine
 semantic_version


### PR DESCRIPTION
 * Use select_related instead of prefetch_related to get everything in
   one query
* Use .iterator() instead of chunked_iterator() which required an
   additional sort operation
    
The result is not much faster on my dev machine, but much faster on the
Katello box w/ HDD.
    
closes: #7699
https://pulp.plan.io/issues/7699