### PR TITLE
Extend behavioural tests

### DIFF
--- a/CHANGES/7999.misc
+++ b/CHANGES/7999.misc
@@ -1,0 +1,1 @@
+Added more behavioural tests.


### PR DESCRIPTION
Test content migration when on_demand or immediate importers
are not migrated.

closes #7999
https://pulp.plan.io/issues/7999