### PR TITLE
Add tests for repo/importer/distributor migration re-runs

### DIFF
--- a/CHANGES/8041.misc
+++ b/CHANGES/8041.misc
@@ -1,0 +1,1 @@
+Added tests for RPM repo/importer/distributor migration re-runs.

--- a/pulp_2to3_migration/app/pre_migration.py
+++ b/pulp_2to3_migration/app/pre_migration.py
@@ -669,7 +669,7 @@ def handle_outdated_resources(plan, type_to_repo_ids):
     # Delete old Publications/Distributions which are no longer present in Pulp2.
 
     # It's critical to remove Distributions to avoid base_path overlap.
-    # It make the migration logic easier if we remove old Publications as well.
+    # It makes the migration logic easier if we remove old Publications as well.
 
     # Delete criteria:
     #     - pulp2distributor is no longer in plan

--- a/pulp_2to3_migration/tests/functional/common_plans.py
+++ b/pulp_2to3_migration/tests/functional/common_plans.py
@@ -53,61 +53,63 @@ FILE_COMPLEX_PLAN = json.dumps({
     }]
 })
 
+INITIAL_REPOSITORIES = [
+    {
+        "name": "rpm-empty",
+        "pulp2_importer_repository_id": "rpm-empty",  # policy: immediate
+        "repository_versions": [
+            {
+                "pulp2_repository_id": "rpm-empty",  # content count: 0
+                "pulp2_distributor_repository_ids": ["rpm-empty"]
+            }
+        ]
+    },
+    {
+        "name": "rpm-empty-for-copy",
+        "pulp2_importer_repository_id": "rpm-empty-for-copy",  # policy: immediate
+        "repository_versions": [
+            {
+                "pulp2_repository_id": "rpm-empty-for-copy",  # content count: 0
+                "pulp2_distributor_repository_ids": ["rpm-empty-for-copy"]
+            }
+        ]
+    },
+    {
+        "name": "rpm-with-modules",
+        "pulp2_importer_repository_id": "rpm-with-modules",  # policy: on_demand
+        "repository_versions": [
+            {
+                "pulp2_repository_id": "rpm-with-modules",
+                "pulp2_distributor_repository_ids": ["rpm-with-modules"]
+            }
+        ]
+    },
+    {
+        "name": "rpm-distribution-tree",
+        "pulp2_importer_repository_id": "rpm-distribution-tree",  # policy: on_demand
+        "repository_versions": [
+            {
+                "pulp2_repository_id": "rpm-distribution-tree",
+                "pulp2_distributor_repository_ids": ["rpm-distribution-tree"]
+            }
+        ]
+    },
+    {
+        "name": "srpm-unsigned",
+        "pulp2_importer_repository_id": "srpm-unsigned",  # policy: on_demand
+        "repository_versions": [
+            {
+                "pulp2_repository_id": "srpm-unsigned",
+                "pulp2_distributor_repository_ids": ["srpm-unsigned"]
+            }
+        ]
+    },
+]
+
 RPM_COMPLEX_PLAN = json.dumps({
     "plugins": [{
         "type": "rpm",
-        "repositories": [
-            {
-                "name": "rpm-empty",
-                "pulp2_importer_repository_id": "rpm-empty",  # policy: immediate
-                "repository_versions": [
-                    {
-                        "pulp2_repository_id": "rpm-empty",  # content count: 0
-                        "pulp2_distributor_repository_ids": ["rpm-empty"]
-                    }
-                ]
-            },
-            {
-                "name": "rpm-empty-for-copy",
-                "pulp2_importer_repository_id": "rpm-empty-for-copy",  # policy: immediate
-                "repository_versions": [
-                    {
-                        "pulp2_repository_id": "rpm-empty-for-copy",  # content count: 0
-                        "pulp2_distributor_repository_ids": ["rpm-empty-for-copy"]
-                    }
-                ]
-            },
-            {
-                "name": "rpm-with-modules",
-                "pulp2_importer_repository_id": "rpm-with-modules",  # policy: on_demand
-                "repository_versions": [
-                    {
-                        "pulp2_repository_id": "rpm-with-modules",
-                        "pulp2_distributor_repository_ids": ["rpm-with-modules"]
-                    }
-                ]
-            },
-            {
-                "name": "rpm-distribution-tree",
-                "pulp2_importer_repository_id": "rpm-distribution-tree",  # policy: on_demand
-                "repository_versions": [
-                    {
-                        "pulp2_repository_id": "rpm-distribution-tree",
-                        "pulp2_distributor_repository_ids": ["rpm-distribution-tree"]
-                    }
-                ]
-            },
-            {
-                "name": "srpm-unsigned",
-                "pulp2_importer_repository_id": "srpm-unsigned",  # policy: on_demand
-                "repository_versions": [
-                    {
-                        "pulp2_repository_id": "srpm-unsigned",
-                        "pulp2_distributor_repository_ids": ["srpm-unsigned"]
-                    }
-                ]
-            }
-        ]
+        "repositories": INITIAL_REPOSITORIES,
     }]
 })
 

--- a/pulp_2to3_migration/tests/functional/rpm_base.py
+++ b/pulp_2to3_migration/tests/functional/rpm_base.py
@@ -1,0 +1,90 @@
+import time
+
+from pulpcore.client.pulpcore import Configuration
+from pulpcore.client.pulp_rpm import (
+    ApiClient as RpmApiClient,
+    ContentAdvisoriesApi,
+    # ContentDistributionTreesApi,
+    ContentModulemdDefaultsApi,
+    ContentModulemdsApi,
+    ContentPackagecategoriesApi,
+    ContentPackageenvironmentsApi,
+    ContentPackagegroupsApi,
+    ContentPackagelangpacksApi,
+    ContentPackagesApi,
+    DistributionsRpmApi,
+    PublicationsRpmApi,
+    RemotesRpmApi,
+    RepositoriesRpmApi,
+    RepositoriesRpmVersionsApi,
+)
+from pulpcore.client.pulp_2to3_migration import (
+    ApiClient as MigrationApiClient,
+    MigrationPlansApi,
+)
+
+from pulp_2to3_migration.tests.functional.util import get_psql_smash_cmd
+
+from pulp_smash import cli
+from pulp_smash import config as smash_config
+from pulp_smash.pulp3.bindings import monitor_task, monitor_task_group
+
+from .constants import BINDINGS_CONFIGURATION, TRUNCATE_TABLES_QUERY_BASH
+
+
+class BaseTestRpm:
+    """
+    Test RPM migration re-runs.
+    """
+    smash_cfg = smash_config.get_config()
+    smash_cli_client = cli.Client(smash_cfg)
+    plan_initial = None
+    plan_rerun = None
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Create all the client instances needed to communicate with Pulp.
+        """
+        configuration = Configuration(**BINDINGS_CONFIGURATION)
+
+        rpm_client = RpmApiClient(configuration)
+        migration_client = MigrationApiClient(configuration)
+
+        # Create api clients for all resource types
+        cls.rpm_repo_api = RepositoriesRpmApi(rpm_client)
+        cls.rpm_repo_versions_api = RepositoriesRpmVersionsApi(rpm_client)
+        cls.rpm_remote_api = RemotesRpmApi(rpm_client)
+        cls.rpm_distribution_api = DistributionsRpmApi(rpm_client)
+        cls.rpm_publication_api = PublicationsRpmApi(rpm_client)
+        cls.rpm_content_apis = {
+            'advisory': ContentAdvisoriesApi(rpm_client),
+            # skip until https://pulp.plan.io/issues/8050 is fixed
+            # 'disttree': ContentDistributionTreesApi(rpm_client),
+            'modulemd': ContentModulemdsApi(rpm_client),
+            'modulemd-defaults': ContentModulemdDefaultsApi(rpm_client),
+            'category': ContentPackagecategoriesApi(rpm_client),
+            'environment': ContentPackageenvironmentsApi(rpm_client),
+            'group': ContentPackagegroupsApi(rpm_client),
+            'langpack': ContentPackagelangpacksApi(rpm_client),
+            'package': ContentPackagesApi(rpm_client),
+        }
+        cls.migration_plans_api = MigrationPlansApi(migration_client)
+
+    @classmethod
+    def run_migration(cls, plan):
+        """Run a migration using simple plan."""
+        mp = cls.migration_plans_api.create({'plan': plan})
+        mp_run_response = cls.migration_plans_api.run(mp.pulp_href, {})
+        task = monitor_task(mp_run_response.task)
+        monitor_task_group(task.task_group)
+        return task
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Clean up the database after the set of tests is run.
+        """
+        cmd = get_psql_smash_cmd(TRUNCATE_TABLES_QUERY_BASH)
+        cls.smash_cli_client.run(cmd, sudo=True)
+        time.sleep(0.5)

--- a/pulp_2to3_migration/tests/functional/test_rpm_rerun.py
+++ b/pulp_2to3_migration/tests/functional/test_rpm_rerun.py
@@ -1,0 +1,277 @@
+import json
+import unittest
+
+from collections import defaultdict
+
+from pulp_2to3_migration.tests.functional.util import set_pulp2_snapshot
+
+from .common_plans import INITIAL_REPOSITORIES, RPM_SIMPLE_PLAN, RPM_COMPLEX_PLAN
+from .rpm_base import BaseTestRpm
+
+
+RERUN_REPOSITORIES = INITIAL_REPOSITORIES + [
+    {
+        "name": "rpm-richnweak-deps",
+        "pulp2_importer_repository_id": "rpm-richnweak-deps",  # policy: on_demand
+        "repository_versions": [
+            {
+                "pulp2_repository_id": "rpm-richnweak-deps",
+                "pulp2_distributor_repository_ids": ["rpm-richnweak-deps"]
+            }
+        ]
+    }
+]
+
+RPM_RERUN_PLAN = json.dumps({
+    "plugins": [{
+        "type": "rpm",
+        "repositories": RERUN_REPOSITORIES
+    }]
+})
+
+PULP_2_RPM_DATA = {
+    'repositories': 6,
+    'remotes': 4,
+    'publications': 6,
+    'distributions': 6,
+    'content': {
+        'rpm-empty': {},
+        'rpm-empty-for-copy': {
+            'package': 1
+        },
+        'rpm-with-modules': {
+            'advisory': 6,
+            'modulemd': 10,
+            'modulemd-defaults': 3,
+            'category': 1,
+            'group': 2,
+            'langpack': 1,
+            'package': 34,
+        },
+        'rpm-distribution-tree': {
+            'disttree': 1,
+            'environment': 1,
+            'category': 1,
+            'group': 1,
+            'langpack': 1,
+            'package': 1,
+        },
+        'srpm-unsigned': {
+            'advisory': 2,
+            'category': 1,
+            'group': 2,
+            'langpack': 1,
+            'package': 3,
+        },
+        'rpm-richnweak-deps': {
+            'package': 14,
+        },
+    },
+    'content_total': {
+        'package': 53,
+        'advisory': 8,
+        'modulemd': 10,
+        'modulemd-defaults': 3,
+        'disttree': 1,
+        'environment': 1,
+        'category': 3,
+        'group': 5,
+        'langpack': 3,
+    },
+    'content_added': 15,
+    'versions': {
+        'rpm-empty': 1,
+        'rpm-empty-for-copy': 2,
+        'rpm-with-modules': 3,
+        'rpm-distribution-tree': 2,
+        'srpm-unsigned': 2,
+        'rpm-richnweak-deps': 2
+
+    },
+    'new_repos': 1,
+    'new_remotes': 2,
+    'new_publications': 4,
+    'new_distributions': 5,
+}
+
+
+class BaseTestRpmRerun(BaseTestRpm):
+    """
+    Test RPM migration re-runs.
+    """
+    @classmethod
+    def setUpClass(cls):
+        """
+        Create all the client instances needed to communicate with Pulp and run migrations.
+        """
+        super().setUpClass()
+
+        def collect_migration_data():
+            """Collect data from a migration run to use later for comparison."""
+            data = {
+                'repos': defaultdict(dict),
+                'remotes': defaultdict(dict),
+                'publications': defaultdict(dict),
+                'distributions': defaultdict(dict),
+            }
+            for repo in cls.rpm_repo_api.list().results:
+                data['repos'][repo.name]['created'] = repo.pulp_created
+                latest_version = cls.rpm_repo_versions_api.read(repo.latest_version_href)
+                data['repos'][repo.name]['latest_version_number'] = latest_version.number
+                data['repos'][repo.name]['latest_version_created'] = latest_version.pulp_created
+            for remote in cls.rpm_remote_api.list().results:
+                data['remotes'][remote.name]['created'] = remote.pulp_created
+            for pub in cls.rpm_publication_api.list().results:
+                data['publications'][pub.repository]['created'] = pub.pulp_created
+            for dist in cls.rpm_distribution_api.list().results:
+                data['distributions'][dist.name]['created'] = dist.pulp_created
+            return data
+
+        set_pulp2_snapshot(name='rpm_base_4repos')
+        cls.task_initial = cls.run_migration(cls.plan_initial)
+        cls.first_migration_data = collect_migration_data()
+
+        set_pulp2_snapshot(name='rpm_base_4repos_rerun_changes')
+        cls.task_rerun = cls.run_migration(cls.plan_rerun)
+
+    def test_rpm_only_added_content(self):
+        """
+        Test that only newly added content is migrated on a rerun and not all.
+
+        And that all old one stays as is as well.
+        """
+        content_added = 0
+        for pr in self.task_rerun.progress_reports:
+            if pr.code == 'migrating.content':
+                content_added = pr.done
+                break
+        self.assertEqual(content_added, PULP_2_RPM_DATA['content_added'])
+
+        # content count in total
+        for content_type, api in self.rpm_content_apis.items():
+            with self.subTest(content_type=content_type):
+                self.assertEqual(api.list().count, PULP_2_RPM_DATA['content_total'][content_type])
+
+    def test_rpm_only_added_or_changed_repos(self):
+        """
+        Test that only newly added or changed repos are migrated on a rerun and not all.
+
+        Compare timestamps from initial run. And make sure repos are migrated correctly.
+        """
+        self.assertEqual(self.rpm_repo_api.list().count, PULP_2_RPM_DATA['repositories'])
+        new_repo_count = 0
+        for repo in self.rpm_repo_api.list().results:
+            with self.subTest(repo=repo):
+                if repo.name in self.first_migration_data['repos']:
+                    repo_data = self.first_migration_data['repos'][repo.name]
+                    repo_version = self.rpm_repo_versions_api.list(
+                        repo.pulp_href, number=repo_data['latest_version_number']
+                    ).results[0]
+                    self.assertEqual(repo.pulp_created, repo_data['created'])
+                    self.assertEqual(repo_version.pulp_created, repo_data['latest_version_created'])
+                else:
+                    new_repo_count += 1
+
+                repo_versions = self.rpm_repo_versions_api.list(repo.pulp_href)
+                self.assertEqual(repo_versions.count, PULP_2_RPM_DATA['versions'][repo.name])
+
+                # content count per repo
+                for content_type, api in self.rpm_content_apis.items():
+                    with self.subTest(content_type=content_type):
+                        repo_content = api.list(repository_version=repo.latest_version_href)
+                        self.assertEqual(
+                            repo_content.count,
+                            PULP_2_RPM_DATA['content'][repo.name].get(content_type, 0)
+                        )
+        self.assertEqual(new_repo_count, PULP_2_RPM_DATA['new_repos'])
+
+    def test_rpm_importers_only_added_or_with_changed_config(self):
+        """
+        Test that only newly added or importers which feed changed are migrated on a rerun.
+
+        The only changed feed is for the 'rpm-with-modules' repo.
+        """
+        REPO_FEED_CHANGE = 'rpm-with-modules'
+        self.assertEqual(self.rpm_remote_api.list().count, PULP_2_RPM_DATA['remotes'])
+        new_remote_count = 0
+        for remote in self.rpm_remote_api.list().results:
+            with self.subTest(remote=remote):
+                if remote.name in self.first_migration_data['remotes']:
+                    remote_data = self.first_migration_data['remotes'][remote.name]
+                    repo_name = '-'.join(remote.name.split('-')[1:])
+                    if repo_name == REPO_FEED_CHANGE:
+                        self.assertNotEqual(remote.pulp_created, remote_data['created'])
+                        new_remote_count += 1
+                    else:
+                        self.assertEqual(remote.pulp_created, remote_data['created'])
+                else:
+                    new_remote_count += 1
+
+        self.assertEqual(new_remote_count, PULP_2_RPM_DATA['new_remotes'])
+
+    def test_rpm_distributors_only_added_or_with_changed_config(self):
+        """
+        Test that only newly added or changed distributors are migrated on a rerun.
+
+        New content in a repo forces to recreate publications and distributors.
+        A change in checksum type forces to recreate publications and distributors.
+        A change in relative_url/base_path forces to recreate distributors.
+        """
+        REPO_NEW_CONTENT = 'rpm-empty-for-copy'
+        REPO_REMOVED_CONTENT = 'rpm-with-modules'
+        REPO_CHECKSUMTYPE_CHANGE = 'rpm-distribution-tree'
+        REPO_BASE_PATH_CHANGE = 'srpm-unsigned'
+        CHANGED_PUB_REPOS = (REPO_NEW_CONTENT, REPO_REMOVED_CONTENT, REPO_CHECKSUMTYPE_CHANGE)
+        CHANGED_DIST_REPOS = (
+            REPO_NEW_CONTENT, REPO_REMOVED_CONTENT, REPO_CHECKSUMTYPE_CHANGE, REPO_BASE_PATH_CHANGE
+        )
+        self.assertEqual(self.rpm_publication_api.list().count, PULP_2_RPM_DATA['publications'])
+        self.assertEqual(self.rpm_distribution_api.list().count, PULP_2_RPM_DATA['distributions'])
+        new_publication_count = 0
+        for pub in self.rpm_publication_api.list().results:
+            with self.subTest(pub=pub):
+                if pub.repository in self.first_migration_data['publications']:
+                    pub_data = self.first_migration_data['publications'][pub.repository]
+                    repo_name = self.rpm_repo_api.read(pub.repository).name
+                    if repo_name in CHANGED_PUB_REPOS:
+                        self.assertNotEqual(pub.pulp_created, pub_data['created'])
+                        new_publication_count += 1
+                    else:
+                        self.assertEqual(pub.pulp_created, pub_data['created'])
+                else:
+                    new_publication_count += 1
+
+        self.assertEqual(new_publication_count, PULP_2_RPM_DATA['new_publications'])
+
+        new_distribution_count = 0
+        for dist in self.rpm_distribution_api.list().results:
+            with self.subTest(dist=dist):
+                if dist.name in self.first_migration_data['distributions']:
+                    dist_data = self.first_migration_data['distributions'][dist.name]
+                    repo_name = '-'.join(dist.name.split('-')[1:])
+                    if repo_name in CHANGED_DIST_REPOS:
+                        self.assertNotEqual(dist.pulp_created, dist_data['created'])
+                        new_distribution_count += 1
+                    else:
+                        self.assertEqual(dist.pulp_created, dist_data['created'])
+                else:
+                    new_distribution_count += 1
+
+        self.assertEqual(new_distribution_count, PULP_2_RPM_DATA['new_distributions'])
+
+
+@unittest.skip('empty repos are not migrated until https://pulp.plan.io/issues/6516 is done')
+class TestRpmRerunSimplePlan(BaseTestRpmRerun, unittest.TestCase):
+    """
+    Test RPM repo migration using simple migration plan.
+    """
+    plan_initial = RPM_SIMPLE_PLAN
+    plan_rerun = RPM_SIMPLE_PLAN
+
+
+class TestRpmRerunComplexPlan(BaseTestRpmRerun, unittest.TestCase):
+    """
+    Test RPM repo migration using complex migration plan.
+    """
+    plan_initial = RPM_COMPLEX_PLAN
+    plan_rerun = RPM_RERUN_PLAN


### PR DESCRIPTION
Also a bit of refactor to reuse setUpClass and teardownClass.

closes #8041
https://pulp.plan.io/issues/8041