### PR TITLE
Taught content pre_migration to use consistent ordering.

### DIFF
--- a/CHANGES/7781.bugfix
+++ b/CHANGES/7781.bugfix
@@ -1,0 +1,5 @@
+Taught pre-migration to order content by last-updated.
+
+This lets a migration recover reliably from fatal errors during migration attempts.
+NOTE: this fix assumes the Pulp2 instance is at least at 2.21.5. Earlier versions are
+missing an index in the Mongo database that makes the ordering possible.

--- a/pulp_2to3_migration/app/pre_migration.py
+++ b/pulp_2to3_migration/app/pre_migration.py
@@ -94,7 +94,10 @@ def pre_migrate_content_type(content_model, mutable_type, lazy_type, premigrate_
         pulp2_content_ids = premigrate_hook()
         query_args["id__in"] = pulp2_content_ids
 
-    mongo_content_qs = content_model.pulp2.objects(_last_updated__gte=last_updated, **query_args)
+    mongo_content_qs = content_model.pulp2.objects(
+        _last_updated__gte=last_updated, **query_args
+    ).order_by("_last_updated")
+
     total_content = mongo_content_qs.count()
     _logger.debug('Total count for {type} content to migrate: {total}'.format(
         type=content_type,


### PR DESCRIPTION
This allows retries after migration-failures to pick up from failure-points consistently.

NOTE: In the presence of large migrations, this code requires the index from
https://github.com/pulp/pulp/pull/4011 to exist in Pulp2, or the migration is likely
to fail at the order-by point.

fixes #7781