### PR TITLE
Don't generate sqlite metadata unless Pulp 2 config says so

### DIFF
--- a/CHANGES/7851.bugfix
+++ b/CHANGES/7851.bugfix
@@ -1,0 +1,1 @@
+No longer generate sqlite metadata when publishing unless the Pulp 2 configuration specified to do so.

--- a/pulp_2to3_migration/app/plugin/rpm/repository.py
+++ b/pulp_2to3_migration/app/plugin/rpm/repository.py
@@ -73,7 +73,12 @@ class RpmDistributor(Pulp2to3Distributor):
             if pulp2_checksum_type:
                 checksum_types = {'metadata': pulp2_checksum_type,
                                   'package': pulp2_checksum_type}
-            publish(repo_version.pk, checksum_types=checksum_types)
+            sqlite = pulp2_config.get('generate_sqlite', False)
+            try:
+                publish(repo_version.pk, checksum_types=checksum_types, sqlite_metadata=sqlite)
+            except TypeError:
+                # hack, pulp_rpm <3.9 doesn't support sqlite_metadata kwarg
+                publish(repo_version.pk, checksum_types=checksum_types)
             publication = repo_version.publication_set.first()
 
         # create distribution


### PR DESCRIPTION
pulp_rpm provides a toggle for generating sqlite metadata, defaulting to
off, added in #7852. If the Pulp 2 config does specify generation of
sqlite metadata, then we need to re-enable it.

closes: #7851
https://pulp.plan.io/issues/7851