### PR TITLE
Taught rpm-migration to be more stable in the face of missing treeinfos.

### DIFF
--- a/CHANGES/8084.bugfix
+++ b/CHANGES/8084.bugfix
@@ -1,0 +1,1 @@
+Taught rpm to warn and continue if a Distribution is missing a treeinfo file.

--- a/pulp_2to3_migration/app/plugin/content.py
+++ b/pulp_2to3_migration/app/plugin/content.py
@@ -272,9 +272,28 @@ class ContentMigrationFirstStage(Stage):
                     extra_info = None
                     if is_multi_artifact:
                         extra_info = pulp_2to3_detail_content.get_treeinfo_serialized()
+                        # If we can't find the .treeinfo for the Distribution, warn and skip
+                        if extra_info is None:
+                            _logger.warning(
+                                _(
+                                    "Failed to find or instantiate extra_info for multi-artifact "
+                                    "pulp2 unit_id: {} ; skipping".format(pulp2content.pulp2_id)
+                                )
+                            )
+                            continue
                 else:
                     # create pulp3 content and assign relations if present
                     pulp3content, extra_info = pulp_2to3_detail_content.create_pulp3_content()
+
+                # If we can't find/create the Distribution, warn and skip
+                if pulp3content is None:
+                    _logger.warning(
+                        _(
+                            "Failed to find or instantiate pulp3 content for pulp2 unit_id: {} ;"
+                            " skipping".format(pulp2content.pulp2_id)
+                        )
+                    )
+                    continue
 
                 future_relations = {'pulp2content': pulp2content}
                 if extra_info:

--- a/pulp_2to3_migration/app/plugin/rpm/pulp_2to3_models.py
+++ b/pulp_2to3_migration/app/plugin/rpm/pulp_2to3_models.py
@@ -741,7 +741,7 @@ class Pulp2Distribution(Pulp2to3Content):
         Create a Pulp 3 Distribution content for saving later in a bulk operation.
 
         Returns:
-            dict: a serialized treeinfo data
+            dict: a serialized treeinfo data, or None if no treeinfo can be found.
 
         """
         namespaces = [".treeinfo", "treeinfo"]
@@ -767,7 +767,8 @@ class Pulp2Distribution(Pulp2to3Content):
             # Reset build_timestamp so Pulp will fetch all the addons during the next sync
             treeinfo_serialized['distribution_tree']['build_timestamp'] = 0
             return treeinfo_serialized
-        assert False, "Failed to find treeinfo, something went wrong"
+
+        return None
 
     def create_pulp3_content(self):
         """
@@ -775,12 +776,16 @@ class Pulp2Distribution(Pulp2to3Content):
 
         Returns:
             (DistributionTree, dict): an in-memory DistributionTree content and serialized
-                                      treeinfo data
+                                      treeinfo data. Returns (None, None) if no treeinfo
+                                      can be found.
 
         """
         treeinfo_serialized = self.get_treeinfo_serialized()
-        return (DistributionTree(**treeinfo_serialized["distribution_tree"]),
-                treeinfo_serialized)
+        if treeinfo_serialized is None:
+            return None, None
+        else:
+            return (DistributionTree(**treeinfo_serialized["distribution_tree"]),
+                    treeinfo_serialized)
 
 
 class Pulp2PackageLangpacks(Pulp2to3Content):


### PR DESCRIPTION
fixes #8084