### PR TITLE
Fixed distributor re-run when it was only pre-migrated and then changed

### DIFF
--- a/CHANGES/8195.bugfix
+++ b/CHANGES/8195.bugfix
@@ -1,0 +1,1 @@
+Fixed distributor re-migration case when it was changed in Pulp 2 between migration plan runs.

--- a/pulp_2to3_migration/app/plugin/rpm/repository.py
+++ b/pulp_2to3_migration/app/plugin/rpm/repository.py
@@ -106,6 +106,9 @@ class RpmDistributor(Pulp2to3Distributor):
             bool: True, if a publication needs to be recreated; False if no changes are needed
 
         """
+        if not pulp2distributor.pulp3_publication:
+            return True
+
         new_checksum_type = pulp2distributor.pulp2_config.get('checksum_type')
         current_checksum_type = pulp2distributor.pulp3_publication.cast().metadata_checksum_type
 


### PR DESCRIPTION
The following situation is fixed now:
  * pre-migration for a distributor happened, but migration did not
  * then pulp2 distributor changed
  * then migration plan was run again

closes #8195
https://pulp.plan.io/issues/8195