### PR TITLE
Fix bindings when pulp2_storage_path is null

### DIFF
--- a/CHANGES/8436.bugfix
+++ b/CHANGES/8436.bugfix
@@ -1,0 +1,1 @@
+Fixed the case when listing pulp2content/ endpoint using bindings would fail if content didn't have a storage path in Pulp 2.

--- a/pulp_2to3_migration/app/serializers.py
+++ b/pulp_2to3_migration/app/serializers.py
@@ -143,7 +143,7 @@ class Pulp2ContentSerializer(ModelSerializer):
     pulp2_id = serializers.CharField(max_length=255)
     pulp2_content_type_id = serializers.CharField(max_length=255)
     pulp2_last_updated = serializers.IntegerField()
-    pulp2_storage_path = serializers.CharField()
+    pulp2_storage_path = serializers.CharField(allow_blank=True)
     downloaded = serializers.BooleanField(default=False)
     pulp3_content = DetailRelatedField(
         required=False, allow_null=True, queryset=Pulp2Content.objects.all(),


### PR DESCRIPTION
closes #8436
https://pulp.plan.io/issues/8436