### PR TITLE
Remove Pulp2Content records if content is no longer in Pulp2

### DIFF
--- a/CHANGES/7887.bugfix
+++ b/CHANGES/7887.bugfix
@@ -1,0 +1,1 @@
+Fixed the case when some Pulp 2 content was removed and cleaned up between migration re-runs.

--- a/pulp_2to3_migration/app/serializers.py
+++ b/pulp_2to3_migration/app/serializers.py
@@ -143,7 +143,7 @@ class Pulp2ContentSerializer(ModelSerializer):
     pulp2_id = serializers.CharField(max_length=255)
     pulp2_content_type_id = serializers.CharField(max_length=255)
     pulp2_last_updated = serializers.IntegerField()
-    pulp2_storage_path = serializers.CharField(allow_blank=True)
+    pulp2_storage_path = serializers.CharField(allow_null=True)
     downloaded = serializers.BooleanField(default=False)
     pulp3_content = DetailRelatedField(
         required=False, allow_null=True, queryset=Pulp2Content.objects.all(),

--- a/pulp_2to3_migration/tests/functional/rpm_base.py
+++ b/pulp_2to3_migration/tests/functional/rpm_base.py
@@ -21,6 +21,7 @@ from pulpcore.client.pulp_rpm import (
 from pulpcore.client.pulp_2to3_migration import (
     ApiClient as MigrationApiClient,
     MigrationPlansApi,
+    Pulp2ContentApi,
     Pulp2RepositoriesApi,
 )
 
@@ -70,6 +71,7 @@ class BaseTestRpm:
             'package': ContentPackagesApi(rpm_client),
         }
         cls.migration_plans_api = MigrationPlansApi(migration_client)
+        cls.pulp2content_api = Pulp2ContentApi(migration_client)
         cls.pulp2repositories_api = Pulp2RepositoriesApi(migration_client)
 
     @classmethod


### PR DESCRIPTION
If some content is only pre-migrated and not migrated to Pulp 3,
and then removed from Pulp 2, it can cause a problem with subsequent migration run.
Such content is treated as corrupted but in reality, it's no longer in Pulp 2.
Now such records are removed before any pre-migration starts.

closes #7887
https://pulp.plan.io/issues/7887