### PR TITLE
Fix corrupted content skipping for deb content

### DIFF
--- a/CHANGES/8612.bugfix
+++ b/CHANGES/8612.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug in the deb pipeline that was preventing successfull skipping of corrupted content for migrations with ``skip_corrupted=True``.

--- a/pulp_2to3_migration/app/plugin/deb/pulp_2to3_models.py
+++ b/pulp_2to3_migration/app/plugin/deb/pulp_2to3_models.py
@@ -449,6 +449,11 @@ class Pulp2DebComponentPackage(Pulp2to3Content):
             relative_path=self.package_relative_path,
             sha256=self.package_sha256,
         ).first()
+        if not package:
+            # Perhaps the package was never created because the file was corrupt!
+            # We simply don't create the PackageReleaseComponent (just how the Package
+            # itself was not created) and hope for the best.
+            return (None, None)
         pulp3_package_release_component = pulp3_models.PackageReleaseComponent(
             release_component=release_component,
             package=package,


### PR DESCRIPTION
Could be the fix for: https://pulp.plan.io/issues/8562 (I am not yet sure...)