### PR TITLE
Migrate relationship between repo and importer to Pulp 3

### DIFF
--- a/CHANGES/8626.feature
+++ b/CHANGES/8626.feature
@@ -1,0 +1,1 @@
+Started migrating relationship between repo and importer to Pulp 3.

--- a/pulp_2to3_migration/app/migration.py
+++ b/pulp_2to3_migration/app/migration.py
@@ -425,15 +425,18 @@ def create_repo_version(progress_rv, pulp2_repo, pulp3_remote=None):
                 # exclude the resolved path from further search
                 paths.remove(bad_path)
 
+    pulp3_repo = pulp2_repo.pulp3_repository
     if pulp3_remote:
         pulp2_repo.pulp3_repository_remote = pulp3_remote
         pulp2_repo.save()
+
+        pulp3_repo.remote = pulp3_remote
+        pulp3_repo.save()
 
     if pulp2_repo.is_migrated:
         progress_rv.update(total=F('total') - 1)
         return
 
-    pulp3_repo = pulp2_repo.pulp3_repository
     unit_ids = Pulp2RepoContent.objects.filter(pulp2_repository=pulp2_repo).values_list(
         'pulp2_unit_id', flat=True)
     incoming_content = set(

--- a/pulp_2to3_migration/tests/functional/test_migration_behaviour.py
+++ b/pulp_2to3_migration/tests/functional/test_migration_behaviour.py
@@ -167,7 +167,7 @@ class TestMigrationBehaviour(BaseTestFile, unittest.TestCase):
         """
         Test that pulp2repositories/ endpoint provides info for the migrated Pulp 2 repository.
 
-        Check correctness of the dara for the first repo in the list.
+        Check correctness of the data for the first repo in the list.
         """
         self.run_migration(plan)
         pulp2repository = self.pulp2repositories_api.list(
@@ -185,6 +185,7 @@ class TestMigrationBehaviour(BaseTestFile, unittest.TestCase):
         self.assertEqual(pulp3_repo.latest_version_href, pulp2repository.pulp3_repository_version)
         self.assertEqual(pulp3_remote.url, FILE_URL)
         self.assertEqual(pulp3_remote.policy, 'immediate')
+        self.assertEqual(pulp3_remote.pulp_href, pulp2repository.pulp3_remote_href)
         self.assertEqual(pulp3_pub.manifest, 'PULP_MANIFEST')
         self.assertEqual(pulp3_pub.repository_version, pulp2repository.pulp3_repository_version)
         self.assertEqual(pulp3_pub.distributions[0], pulp3_dist.pulp_href)
@@ -240,6 +241,8 @@ class TestMigrationBehaviour(BaseTestFile, unittest.TestCase):
         pulp2repo1, pulp2repo2 = pulp2repositories
         pulp3_remote1 = self.file_remote_api.read(pulp2repo1.pulp3_remote_href)
         pulp3_remote2 = self.file_remote_api.read(pulp2repo2.pulp3_remote_href)
+        pulp3_repo1 = self.file_repo_api.read(pulp2repo1.pulp3_repository_href)
+        pulp3_repo2 = self.file_repo_api.read(pulp2repo2.pulp3_repository_href)
 
         self.assertEqual(pulp2repo1.pulp2_repo_id, 'file')
         self.assertEqual(pulp2repo2.pulp2_repo_id, 'file-many')
@@ -249,6 +252,8 @@ class TestMigrationBehaviour(BaseTestFile, unittest.TestCase):
         self.assertEqual(pulp3_remote2.url, FILE_URL)
         self.assertEqual(pulp3_remote1.policy, 'on_demand')
         self.assertEqual(pulp3_remote2.policy, 'immediate')
+        self.assertEqual(pulp3_repo1.remote, pulp2repo1.pulp3_remote_href)
+        self.assertEqual(pulp3_repo2.remote, pulp2repo2.pulp3_remote_href)
 
     def test_distributor_different_repo(self):
         """
@@ -280,6 +285,7 @@ class TestMigrationBehaviour(BaseTestFile, unittest.TestCase):
         self.run_migration(IMPORTER_NO_REPO_PLAN)
         pulp2repository = self.pulp2repositories_api.list().results[0]
         pulp3_remote = self.file_remote_api.read(pulp2repository.pulp3_remote_href)
+        pulp3_repo = self.file_repo_api.read(pulp2repository.pulp3_repository_href)
 
         self.assertEqual(self.pulp2repositories_api.list().count, 1)
         self.assertEqual(self.file_remote_api.list().count, 1)
@@ -287,6 +293,7 @@ class TestMigrationBehaviour(BaseTestFile, unittest.TestCase):
         self.assertEqual(pulp2repository.pulp2_repo_id, 'file')
         self.assertEqual(pulp3_remote.url, FILE_MANY_URL)
         self.assertEqual(pulp3_remote.policy, 'on_demand')
+        self.assertEqual(pulp3_repo.remote, pulp2repository.pulp3_remote_href)
 
     def test_distributor_no_repo(self):
         """Test that a distributor can be migrated without its native Pulp 2 repo."""
@@ -333,6 +340,7 @@ class TestMigrationBehaviour(BaseTestFile, unittest.TestCase):
         self.assertEqual(self.file_repo_versions_api.list(pulp3_repo.pulp_href).count, 2)
         self.assertEqual(repo_content.count, 3)
         self.assertEqual(pulp2repository.pulp2_repo_id, 'file')
+        self.assertEqual(pulp3_repo.remote, pulp2repository.pulp3_remote_href)
         self.assertEqual(pulp3_pub.repository_version, pulp2repository.pulp3_repository_version)
         self.assertEqual(pulp3_pub.distributions[0], pulp3_dist.pulp_href)
         self.assertEqual(pulp3_dist.base_path, 'file')

--- a/pulp_2to3_migration/tests/functional/test_migration_plan_changes.py
+++ b/pulp_2to3_migration/tests/functional/test_migration_plan_changes.py
@@ -96,25 +96,40 @@ class TestMigrationPlanChanges(BaseTestFile, unittest.TestCase):
         pulp2repo_file_1run = self.pulp2repositories_api.list(pulp2_repo_id='file').results[0]
         pulp2repo_filemany_1run = self.pulp2repositories_api.list(
             pulp2_repo_id='file-many').results[0]
+        pulp3_repo_file_1run = self.file_repo_api.read(pulp2repo_file_1run.pulp3_repository_href)
+        pulp3_repo_filemany_1run = self.file_repo_api.read(
+            pulp2repo_filemany_1run.pulp3_repository_href
+        )
         pulp3_remote_file_1run = self.file_remote_api.read(pulp2repo_file_1run.pulp3_remote_href)
         pulp3_remote_filemany_1run = self.file_remote_api.read(
             pulp2repo_filemany_1run.pulp3_remote_href
         )
+
+        self.assertEqual(pulp3_remote_file_1run.url, FILE_URL)
+        self.assertEqual(pulp3_remote_filemany_1run.url, FILE_MANY_URL)
+        self.assertEqual(pulp3_repo_file_1run.remote, pulp2repo_file_1run.pulp3_remote_href)
+        self.assertEqual(pulp3_repo_filemany_1run.remote, pulp2repo_filemany_1run.pulp3_remote_href)
 
         # run a plan with swapped importers
         self.run_migration(FILE_IMPORTER_DIFF_PLAN)
         pulp2repo_file_2run = self.pulp2repositories_api.list(pulp2_repo_id='file').results[0]
         pulp2repo_filemany_2run = self.pulp2repositories_api.list(
             pulp2_repo_id='file-many').results[0]
+        pulp3_repo_file_2run = self.file_repo_api.read(pulp2repo_file_2run.pulp3_repository_href)
+        pulp3_repo_filemany_2run = self.file_repo_api.read(
+            pulp2repo_filemany_2run.pulp3_repository_href
+        )
         pulp3_remote_file_2run = self.file_remote_api.read(pulp2repo_file_2run.pulp3_remote_href)
         pulp3_remote_filemany_2run = self.file_remote_api.read(
             pulp2repo_filemany_2run.pulp3_remote_href
         )
 
-        self.assertEqual(pulp3_remote_file_1run.url, FILE_URL)
-        self.assertEqual(pulp3_remote_filemany_1run.url, FILE_MANY_URL)
+        # should be swapped between run 1 and 2
         self.assertEqual(pulp3_remote_file_1run, pulp3_remote_filemany_2run)
         self.assertEqual(pulp3_remote_filemany_1run, pulp3_remote_file_2run)
+        # both Pulp2Repository and Pulp 3 "Repository" should still match
+        self.assertEqual(pulp3_repo_file_2run.remote, pulp2repo_file_2run.pulp3_remote_href)
+        self.assertEqual(pulp3_repo_filemany_2run.remote, pulp2repo_filemany_2run.pulp3_remote_href)
 
     def test_distributor_swap(self):
         """


### PR DESCRIPTION
Populate the "remote" field on the Pulp 3 repository model with the
information stored in the Pulp2Repositories table, so that it can
survive post-migration.

closes: #8626
https://pulp.plan.io/issues/8626