### PR TITLE
Do not migrate unsupported metadata.

### DIFF
--- a/CHANGES/8400.bugfix
+++ b/CHANGES/8400.bugfix
@@ -1,0 +1,1 @@
+Stopped migrating unsupported metadata, like .zck, which could have been imported into some old Pulp 2 version.

--- a/pulp_2to3_migration/app/plugin/rpm/migrator.py
+++ b/pulp_2to3_migration/app/plugin/rpm/migrator.py
@@ -21,6 +21,15 @@ from pulp_rpm.app.models import (
 )
 from pulp_rpm.app.tasks.synchronizing import RpmContentSaver
 
+from pulpcore.plugin.stages import (
+    ArtifactSaver,
+    RemoteArtifactSaver,
+    ResolveContentFutures,
+    Stage,
+    QueryExistingArtifacts,
+    QueryExistingContents,
+)
+
 from . import pulp2_models
 
 from .pulp_2to3_models import (
@@ -42,14 +51,7 @@ from .repository import (
     RpmImporter,
 )
 
-from pulpcore.plugin.stages import (
-    ArtifactSaver,
-    RemoteArtifactSaver,
-    ResolveContentFutures,
-    Stage,
-    QueryExistingArtifacts,
-    QueryExistingContents,
-)
+from .utils import exclude_unsupported_metadata
 
 from . import package_utils
 
@@ -126,6 +128,9 @@ class RpmMigrator(Pulp2to3PluginMigrator):
     }
     multi_artifact_types = {
         'distribution': Pulp2Distribution
+    }
+    premigrate_hook = {
+        'yum_repo_metadata_file': exclude_unsupported_metadata,
     }
 
     @classmethod

--- a/pulp_2to3_migration/app/plugin/rpm/utils.py
+++ b/pulp_2to3_migration/app/plugin/rpm/utils.py
@@ -1,0 +1,13 @@
+from mongoengine.queryset.visitor import Q as mongo_Q
+
+from .pulp2_models import YumMetadataFile
+
+
+def exclude_unsupported_metadata():
+    """
+    Exclude .zck and .xz metadata from the list of content to premigrate.
+    """
+    exclude_zck = mongo_Q(data_type__not__endswith='_zck')
+    exclude_xz = mongo_Q(data_type__not__endswith='_xz')
+    supported_content = YumMetadataFile.objects.filter(exclude_zck & exclude_xz)
+    return [c.id for c in supported_content]


### PR DESCRIPTION
Exclude from premigration any data type which ends with _zck or _xz in repomd.xml.

closes #8400
https://pulp.plan.io/issues/8400