### PR TITLE
Set build_timestamp for distribution trees

### DIFF
--- a/CHANGES/8566.bugfix
+++ b/CHANGES/8566.bugfix
@@ -1,0 +1,1 @@
+Fixed migration of CentOS8 distribution trees.

--- a/pulp_2to3_migration/app/plugin/rpm/pulp_2to3_models.py
+++ b/pulp_2to3_migration/app/plugin/rpm/pulp_2to3_models.py
@@ -764,8 +764,14 @@ class Pulp2Distribution(Pulp2to3Content):
                 if variant['repository'] == '.':
                     variants[name] = variant
             treeinfo_serialized['variants'] = variants
-            # Reset build_timestamp so Pulp will fetch all the addons during the next sync
-            treeinfo_serialized['distribution_tree']['build_timestamp'] = 0
+            # Set older timestamp so Pulp will fetch all the addons during the next sync
+            # We can't reset it to 0, some creative repository providers use the same
+            # name/release in many distribution trees and the only way to distinguish tem is by
+            # the build timestamp. e.g. CentOS 8 BaseOs, Appstream, PowerTools, HighAvailability.
+            orig_build_timestamp = int(
+                float(treeinfo_serialized['distribution_tree']['build_timestamp'])
+            )
+            treeinfo_serialized['distribution_tree']['build_timestamp'] = orig_build_timestamp - 1
             return treeinfo_serialized
 
         return None


### PR DESCRIPTION
For some distribution trees, their build timestamp is the only way
to identify them uniquely. Repositories like CentOS 8 BaseOS, Appstream,
PowerTools, HighAvailability, all use the same distribution tree name and release.

For migration/stages pipeline to work correctly, each Artifact of multi-artifact
content needs its ContentArtifact which is created at ContentSaver stage only for
non-saved content.
If the build timestamp is not set and distribution trees are not uniquely identified,
depending on the order of migration, some images might be without a ContentArtifact
which will lead to the migration error:
ValueError: No declared artifact with relative path ".treeinfo" for content "<DistributionTree: pk=...>".

closes #8566
https://pulp.plan.io/issues/8566