### PR TITLE
Fix migration of on_demand distribution trees which do not have images.

### DIFF
--- a/CHANGES/8817.bugfix
+++ b/CHANGES/8817.bugfix
@@ -1,0 +1,1 @@
+Fix migration of on_demand distribution (kickstart) trees when they do no have any images, e.g. CentOS 8 High Availability repo.


### PR DESCRIPTION
closes #8817
https://pulp.plan.io/issues/8817