### PR TITLE
Use checksum type of a package for publication if it's not configured.

### DIFF
--- a/CHANGES/8725.bugfix
+++ b/CHANGES/8725.bugfix
@@ -1,0 +1,4 @@
+Ensure a checksum type of a package is used for publications when a checksum type was not explicitly configured in Pulp 2.
+
+If you plan to perform sync from the migrated Pulp 3 to a Pulp 2 instance, this fix is important, otherwise you can ignore it.
+If you've already started migration of the RPM plugin to Pulp 3, reset the migration for it and start again.


### PR DESCRIPTION
This doesn't fix users in the middle of RPM plugin migration,
they would need to reset RPM migration and start it again.

closes #8725
https://pulp.plan.io/issues/8725