### PR TITLE
Bump pulpocore version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pulpcore>=3.12
+pulpcore>=3.13
 mongoengine
 semantic_version
 jsonschema>=3.0


### PR DESCRIPTION
It was done for the 0.12 release branch but not for the master.
Bringing it up to date.
[noissue]