### PR TITLE
Migrate deb importers without a releases field

### DIFF
--- a/CHANGES/8928.bugfix
+++ b/CHANGES/8928.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug causing deb migrations to fail if there are Pulp 2 importers withou a releases field.

--- a/pulp_2to3_migration/app/plugin/deb/repository.py
+++ b/pulp_2to3_migration/app/plugin/deb/repository.py
@@ -33,7 +33,7 @@ class DebImporter(Pulp2to3Importer):
         """
         pulp2_config = pulp2importer.pulp2_config
         base_config, name = cls.parse_base_config(pulp2importer, pulp2_config)
-        base_config['distributions'] = pulp2_config.get('releases').replace(',', ' ')
+        base_config['distributions'] = pulp2_config.get('releases', 'stable').replace(',', ' ')
         components = pulp2_config.get('components')
         if components:
             base_config['components'] = components.replace(',', ' ')


### PR DESCRIPTION
Closes #8928
https://pulp.plan.io/issues/8928

For Katello it would be good if this is also cherry picked to the `0.11` branch.