### PR TITLE
Drop support for Python 3.6 and 3.7

### DIFF
--- a/CHANGES/9038.removal
+++ b/CHANGES/9038.removal
@@ -1,0 +1,1 @@
+Dropped support for Python 3.6 and 3.7.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author='Pulp Team',
     author_email='pulp-list@redhat.com',
     url='http://www.pulpproject.org',
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     install_requires=requirements,
     include_package_data=True,
     packages=find_packages(exclude=['tests', 'tests.*']),
@@ -23,8 +23,8 @@ setup(
         'Framework :: Django',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ),
     entry_points={
         'pulpcore.plugin': [


### PR DESCRIPTION
This is waiting on pulp/pulp-oci-images#100. I'm waiting for more feedback before I merge.

fixes #9038