### PR TITLE
Fix modular errata migration

### DIFF
--- a/CHANGES/8874.bugfix
+++ b/CHANGES/8874.bugfix
@@ -1,0 +1,1 @@
+Fixed modular errata migration.

--- a/pulp_2to3_migration/app/plugin/rpm/pulp_2to3_models.py
+++ b/pulp_2to3_migration/app/plugin/rpm/pulp_2to3_models.py
@@ -410,7 +410,13 @@ class Pulp2Erratum(Pulp2to3Content):
             col.name = collection.get('name')
             module = collection.get('module')
             if module:
-                col.module = cr.UpdateCollectionModule(**module)
+                cr_module = cr.UpdateCollectionModule()
+                cr_module.name = module['name']
+                cr_module.stream = module['stream']
+                cr_module.version = int(module['version'])
+                cr_module.context = module['context']
+                cr_module.arch = module['arch']
+                col.module = cr_module
 
             for package in collection.get('packages', []):
                 pkg = cr.UpdateCollectionPackage()


### PR DESCRIPTION
Wrong initialization of UpdateCollectionModule in createrepo_c which
led to all fields being set to null didn't cause any failures but
produced a wrong result `<module version=0/>`.

closes #8874
https://pulp.plan.io/issues/8874