### PR TITLE
Fix CI release job by updating /etc/pulp/settings.py

### DIFF
--- a/.github/workflows/scripts/post_before_install.sh
+++ b/.github/workflows/scripts/post_before_install.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -mveuo pipefail
-
-export MONGODB_IP=$(ip address show dev docker0 | grep -o "inet [0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | grep -o "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*")
-sed -i "s/'seeds': 'localhost:27017'/'seeds': '$MONGODB_IP:27017'/g" $GITHUB_WORKSPACE/pulp_2to3_migration/app/settings.py
-sed -i "s/'username': ''/'username': 'ci_cd'/g" $GITHUB_WORKSPACE/pulp_2to3_migration/app/settings.py
-sed -i "s/'password': ''/'password': 'ci_cd'/g" $GITHUB_WORKSPACE/pulp_2to3_migration/app/settings.py


### PR DESCRIPTION
Fixing the CI release test job which installs pulp-2to3-migration as a
package (instead of the project files). So we need to use
/etc/pulp/settings.py.

[noissue]