### PR TITLE
Fix CI release job by updating /etc/pulp/settings.py

### DIFF
--- a/.github/workflows/scripts/post_before_install.sh
+++ b/.github/workflows/scripts/post_before_install.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -mveuo pipefail
-
-export MONGODB_IP=$(ip address show dev docker0 | grep -o "inet [0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | grep -o "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*")
-sed -i "s/'seeds': 'localhost:27017'/'seeds': '$MONGODB_IP:27017'/g" $GITHUB_WORKSPACE/pulp_2to3_migration/app/settings.py
-sed -i "s/'username': ''/'username': 'ci_cd'/g" $GITHUB_WORKSPACE/pulp_2to3_migration/app/settings.py
-sed -i "s/'password': ''/'password': 'ci_cd'/g" $GITHUB_WORKSPACE/pulp_2to3_migration/app/settings.py

--- a/.github/workflows/scripts/post_before_script.sh
+++ b/.github/workflows/scripts/post_before_script.sh
@@ -2,8 +2,33 @@
 
 set -euv
 
-sudo sed -i  "s/bindIp: 127.0.0.1/bindIp: 127.0.0.1,$(ip address show dev docker0 | grep -o "inet [0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | grep -o "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*")/g" /etc/mongod.conf
+export MONGODB_IP=$(ip address show dev docker0 | grep -o "inet [0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | grep -o "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*")
+
+sudo sed -i  "s/bindIp: 127.0.0.1/bindIp: 127.0.0.1,$MONGODB_IP/g" /etc/mongod.conf
 sudo systemctl restart mongod
+
+# update settings to configure our mongo install
+cmd_prefix bash -c "cat >> /etc/pulp/settings.py <<EOF
+PULP2_MONGODB = {
+  'name': 'pulp_database',
+  'seeds': '$MONGODB_IP:27017',
+  'username': 'ci_cd',
+  'password': 'ci_cd',
+  'replica_set': '',
+  'ssl': False,
+  'ssl_keyfile': '',
+  'ssl_certfile': '',
+  'verify_ssl': True,
+  'ca_path': '/etc/pki/tls/certs/ca-bundle.crt',
+}
+EOF"
+
+# Restarting single container services
+cmd_prefix bash -c "s6-svc -r /var/run/s6/services/pulpcore-api"
+cmd_prefix bash -c "s6-svc -r /var/run/s6/services/pulpcore-content"
+cmd_prefix bash -c "s6-svc -r /var/run/s6/services/pulpcore-resource-manager"
+cmd_prefix bash -c "s6-svc -r /var/run/s6/services/pulpcore-worker@1"
+cmd_prefix bash -c "s6-svc -r /var/run/s6/services/pulpcore-worker@2"
 
 # install mongo and copy a script which we need to use for func tests to roll out a pulp 2 snapshot
 cmd_prefix bash -c "cat > /etc/yum.repos.d/mongodb-org-3.6.repo <<EOF


### PR DESCRIPTION
Fixing the CI release test job which installs pulp-2to3-migration as a
package (instead of the project files). So we need to use
/etc/pulp/settings.py.

[noissue]

(cherry picked from commit 0867a81f2708a51d6d51f1a1390c05393a13b032)