### PR TITLE
Add DEB_COMPONENT_BATCH_SIZE setting

### DIFF
--- a/CHANGES/9564.bugfix
+++ b/CHANGES/9564.bugfix
@@ -1,0 +1,1 @@
+deb_components now use a default batch size of 50 to avoid CursorNotFound errors during pre_migration for this one to many type.

--- a/CHANGES/9564.feature
+++ b/CHANGES/9564.feature
@@ -1,0 +1,1 @@
+Added the `DEB_COMPONENT_BATCH_SIZE` setting, so users can individually control the batch size for this one to many type.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -98,6 +98,12 @@ setups only.
 
 The main sign that `CONTENT_PREMIGRATION_BATCH_SIZE` needs to go down is the ``pymongo.errors.CursorNotFound: Cursor not found`` errors in logs.
 
+In addition you may also configure `DEB_COMPONENT_BATCH_SIZE` which starts with a default of 50.
+Since each `deb_component` creates a large number of Pulp2to3Content during pre_migration, it is
+appropriate to set a significantly lower batch size, as compared to other types! You can identify
+``CursorNotFound`` errors, caused by `deb_component` migration, by checking if the backtrace passes
+through the ``pulp_2to3_migration/app/plugin/deb/pulp_2to3_models.py`` file.
+
 .. note::
 
     If you experience Pulp 3 workers timing out during the migration, consider making them more

--- a/pulp_2to3_migration/app/pre_migration.py
+++ b/pulp_2to3_migration/app/pre_migration.py
@@ -104,7 +104,14 @@ def pre_migrate_content_type(content_model, mutable_type, lazy_type, premigrate_
                 pulp2_id__in=content_ids_to_delete
             ).delete()
 
-    batch_size = settings.CONTENT_PREMIGRATION_BATCH_SIZE or DEFAULT_BATCH_SIZE
+    batch_size = (
+        settings.DEB_COMPONENT_BATCH_SIZE
+        if content_model.pulp2.TYPE_ID == "deb_component"
+        else settings.CONTENT_PREMIGRATION_BATCH_SIZE or DEFAULT_BATCH_SIZE
+    )
+    message = 'Pre-migrate is using batch size "{}" for Pulp 2 content type "{}".'
+    _logger.debug(message.format(batch_size, content_model.pulp2.TYPE_ID))
+
     pulp2content = []
     pulp2mutatedcontent = []
     content_type = content_model.pulp2.TYPE_ID

--- a/pulp_2to3_migration/app/settings.py
+++ b/pulp_2to3_migration/app/settings.py
@@ -14,3 +14,7 @@ PULP2_MONGODB = {
 ALLOWED_CONTENT_CHECKSUMS = ['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']
 
 CONTENT_PREMIGRATION_BATCH_SIZE = 1000
+
+# Since each deb_component creates a large number of Pulp2to3Content we need a much lower batch size
+# for this type, in order to avoid CursorNotFound errors!
+DEB_COMPONENT_BATCH_SIZE = 50


### PR DESCRIPTION
closes #9564
https://pulp.plan.io/issues/9564

Since each deb_components creates a large number of Pulp2to3Content we
need a much lower batch size for this type.