### PR TITLE
Guard pulp3_remote from importer clearing

### DIFF
--- a/CHANGES/8968.bugfix
+++ b/CHANGES/8968.bugfix
@@ -1,0 +1,1 @@
+Fixed ``'NoneType' object has no attribute 'delete'`` error during migration re-runs.

--- a/pulp_2to3_migration/app/pre_migration.py
+++ b/pulp_2to3_migration/app/pre_migration.py
@@ -605,7 +605,8 @@ def pre_migrate_importer(repo_id, importer_types):
         if last_updated != importer.pulp2_last_updated:
             # remove Remote in case of feed change
             if importer.pulp2_config.get('feed') != importer_data.config.get('feed'):
-                importer.pulp3_remote.delete()
+                if importer.pulp3_remote:
+                    importer.pulp3_remote.delete()
                 importer.pulp3_remote = None
                 # do not flip is_migrated to False for LCE for at least once migrated importer
 


### PR DESCRIPTION
closes #8968
https://pulp.plan.io/issues/8968

We have hit the above issue while 2to3 migrating SLES importers.
Apparently this is sometimes called for SLES importers that already have
their pulp3_remote set to None, resulting in:

'NoneType' object has no attribute 'delete'

We did not perform any deeper analysis of why this is the case, but
simply added this guard to fix the problem.