### PR TITLE
Fixes #497 - local variable 'item' referenced before assignment

### DIFF
--- a/CHANGES/497.bugfix
+++ b/CHANGES/497.bugfix
@@ -1,0 +1,1 @@
+Fixed local variable 'item' referenced before assignment

--- a/pulp_2to3_migration/app/plugin/docker/migrator.py
+++ b/pulp_2to3_migration/app/plugin/docker/migrator.py
@@ -233,18 +233,17 @@ class InterrelateContent(Stage):
             digest = manifest['digest']
             for item in man_list:
                 if item.digest == digest:
+                    platform = manifest['platform']
+                    thru = ManifestListManifest(manifest_list=item, image_manifest=dc.content,
+                                                architecture=platform['architecture'],
+                                                os=platform['os'],
+                                                features=platform.get('features', ''),
+                                                variant=platform.get('variant', ''),
+                                                os_version=platform.get('os.version', ''),
+                                                os_features=platform.get('os.features', '')
+                                                )
+                    mlm.append(thru)
                     break
-            platform = manifest['platform']
-            thru = ManifestListManifest(manifest_list=item, image_manifest=dc.content,
-                                        architecture=platform['architecture'],
-                                        os=platform['os'],
-                                        features=platform.get('features', ''),
-                                        variant=platform.get('variant', ''),
-                                        os_version=platform.get('os.version', ''),
-                                        os_features=platform.get('os.features', '')
-                                        )
-            mlm.append(thru)
-
         return mlm
 
 


### PR DESCRIPTION
This is to fix this error during the content migration:

error:
    traceback: |2
        File "/usr/lib/python3.6/site-packages/rq/worker.py", line 936, in perform_job
          rv = job.perform()
        File "/usr/lib/python3.6/site-packages/rq/job.py", line 684, in perform
          self._result = self._execute()
        File "/usr/lib/python3.6/site-packages/rq/job.py", line 690, in _execute
          return self.func(*self.args, **self.kwargs)
        File "/usr/lib/python3.6/site-packages/pulp_2to3_migration/app/tasks/migrate.py", line 81, in migrate_from_pulp2
          migrate_content(plan, skip_corrupted=skip_corrupted)
        File "/usr/lib/python3.6/site-packages/pulp_2to3_migration/app/migration.py", line 55, in migrate_content
          plugin.migrator.migrate_content_to_pulp3(skip_corrupted=skip_corrupted)
        File "/usr/lib/python3.6/site-packages/pulp_2to3_migration/app/plugin/docker/migrator.py", line 106, in migrate_content_to_pulp3
          loop.run_until_complete(dm.create())
        File "/usr/lib64/python3.6/asyncio/base_events.py", line 484, in run_until_complete
          return future.result()
        File "/usr/lib/python3.6/site-packages/pulp_2to3_migration/app/plugin/content.py", line 89, in create
          await pipeline
        File "/usr/lib/python3.6/site-packages/pulpcore/plugin/stages/api.py", line 225, in create_pipeline
          await asyncio.gather(*futures)
        File "/usr/lib/python3.6/site-packages/pulpcore/plugin/stages/api.py", line 43, in __call__
          await self.run()
        File "/usr/lib/python3.6/site-packages/pulp_2to3_migration/app/plugin/docker/migrator.py", line 154, in run
          thru = self.relate_manifest_to_list(dc)
        File "/usr/lib/python3.6/site-packages/pulp_2to3_migration/app/plugin/docker/migrator.py", line 234, in relate_manifest_to_list
          thru = ManifestListManifest(manifest_list=item, image_manifest=dc.content,
    description: local variable 'item' referenced before assignment