### PR TITLE
Escape django template syntax in xml when rendering filelist

### DIFF
--- a/CHANGES/496.bugfix
+++ b/CHANGES/496.bugfix
@@ -1,0 +1,1 @@
+Escape django template syntax in xml when rendering filelist

--- a/pulp_2to3_migration/app/plugin/rpm/xml_utils.py
+++ b/pulp_2to3_migration/app/plugin/rpm/xml_utils.py
@@ -19,7 +19,8 @@ from django.template.defaulttags import TemplateTagNode
 
 ESCAPE_TEMPLATE_VARS_TAGS = {
     'primary': ('description', 'summary'),
-    'other': ('changelog',)
+    'other': ('changelog',),
+    'filelists': ('file',)
 }
 METADATA_TYPES = ('primary', 'other', 'filelists')
 
@@ -141,6 +142,8 @@ def render_filelists(template, checksum):
         str: a rendered filelists.xml snippet
 
     """
+    for tag in ESCAPE_TEMPLATE_VARS_TAGS['filelists']:
+        template = _escape_django_syntax_chars(template, tag)
     context = Context({'pkgid': checksum})
     return Template(template).render(context)
 


### PR DESCRIPTION
closes #496

added bugfix file