### PR TITLE
Make DistributionTree migration compatible with pulp_rpm 3.17+.

### DIFF
--- a/CHANGES/491.bugfix
+++ b/CHANGES/491.bugfix
@@ -1,0 +1,4 @@
+Fixed DistributionTree (kickstart tree) migration for pulp_rpm 3.17+.
+
+Alma Linux 8 or CentOS 8 repos migration will no longer fail with:
+No declared artifact with relative path "images/boot.iso" (or ".treeinfo").

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pulpcore>=3.15.0
+pulpcore>=3.18.0
 pymongo<4.0
 mongoengine
 semantic_version


### PR DESCRIPTION
closes #491