### PR TITLE
Fix call to remove_content() with QuerySet object

### DIFF
--- a/CHANGES/550.bugfix
+++ b/CHANGES/550.bugfix
@@ -1,0 +1,6 @@
+Fixed issue where migration.py passes a Content object to remove_content(),
+which ends up breaking pulpcore's remove_content() further down the line with
+a traceback stating, 'Content' object has no attribute 'count'.
+
+Pulpcore's remove_content() will not face this issue anymore as it will now
+always receive a QuerySet object from migration.py.

--- a/pulp_2to3_migration/app/migration.py
+++ b/pulp_2to3_migration/app/migration.py
@@ -433,7 +433,7 @@ def create_repo_version(progress_rv, pulp2_repo, pulp3_remote=None):
             else:
                 # It's not a duplicated path but it overlaps with some other in the version,
                 # it should be removed from the version to resolve the conflict.
-                version.remove_content(cas_with_conflicts[0].content)
+                version.remove_content(Content.objects.filter(pk__in=cas_with_conflicts[0].content.pk))
                 _logger.info(
                     _(
                         'Overlapping paths have been found in Pulp 3 repo `{repo}`: Removed '


### PR DESCRIPTION
This PR was originally sent as a pulpcore change but that was misplaced in terms of code.

This PR fixes a situation where the migration plugin calls `remove_content()` and passes it a `Content` object instead of a `QuerySet`. The pulpcore `repository.py` code then checks for the `count()` method for the passed object which _is_ implemented for `QuerySet` but not for `Content`.

So passing a `Content` object causes pulpcore's `repository.py`'s `remove_content()` to fail due to the missing `count()` method.
The fix I'm implementing here is to build a `QuerySet` out of this single `Content` object so as to satisfy pulpcore.