### PR TITLE
Fix invalid BSON size error when migrating docker contents

### DIFF
--- a/CHANGES/578.bugfix
+++ b/CHANGES/578.bugfix
@@ -1,0 +1,7 @@
+Fix invalid BSON size error when migrating docker contents
+
+The size limit for a single document in Mongodb is 16MB so
+migrating many docker tags could exceed this limit. This commit
+fixes this issue by fetching the docker tags in a specified
+batch size instead of fetching all and returning a large
+results into a single document.

--- a/pulp_2to3_migration/app/plugin/docker/utils.py
+++ b/pulp_2to3_migration/app/plugin/docker/utils.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from pulp_2to3_migration.app.constants import DEFAULT_BATCH_SIZE
 from . import pulp2_models
 
 
@@ -8,19 +10,25 @@ def find_tags():
     Prefer schema2 over schema1.
     """
 
+    batch_size = settings.CONTENT_PREMIGRATION_BATCH_SIZE or DEFAULT_BATCH_SIZE
+
     # sort the schema version in desc mode.
     sort_stage = {"$sort": {"schema_version": -1}}
     # group tags by name and repo_id; take just first result out of the 2 tags with the same name
-    group_stage1 = {
+    group_stage = {
         "$group": {
             "_id": {"name": "$name", "repo_id": "$repo_id"},
             "tags_id": {"$first": "$_id"},
         }
     }
-    group_stage2 = {"$group": {"_id": None, "tags_ids": {"$addToSet": "$tags_id"}}}
+    # get only the require field to minimize the result BSON size
+    project_stage = {"$project": {"_id": 0, "tags_id": 1}}
     result = pulp2_models.Tag.objects.aggregate(
-        [sort_stage, group_stage1, group_stage2], allowDiskUse=True
-    )
-    if result._has_next():
-        return result.next()["tags_ids"]
-    return []
+        [sort_stage, group_stage, project_stage], allowDiskUse=True
+    ).batch_size(batch_size)
+
+    tags_ids = set([])
+    for tag in result:
+        tags_ids.add(tag["tags_id"])
+
+    return list(tags_ids)


### PR DESCRIPTION
The size limit for a single document in Mongodb is 16MB so
migrating many docker tags could exceed this limit. This commit
fixes this issue by fetching the docker tags in a specified
batch size instead of fetching all and returning a large
results into a single document.

closes #578