### PR TITLE
Fix premigrate_hook results exceeding BSON limit

### DIFF
--- a/CHANGES/583.bugfix
+++ b/CHANGES/583.bugfix
@@ -1,0 +1,5 @@
+Fix premigrate_hook results exceeding BSON limit
+
+Use pagination to perform query returned by premigrate_hook.
+This will limit each query size and will prevent the BSON too
+large error. Mongodb has 16MB BSON limit for query size.


### PR DESCRIPTION
Use pagination to perform query returned by premigrate_hook.
This will limit each query size and will prevent the BSON too
large error. Mongodb has 16MB BSON limit for query size.

closes #583